### PR TITLE
TASK-54895: Adjust the height of task comment drawer header

### DIFF
--- a/task-management/src/main/webapp/skin/css/tasksCommentDrawer.less
+++ b/task-management/src/main/webapp/skin/css/tasksCommentDrawer.less
@@ -129,6 +129,11 @@
   .drawerTitle > * {
     flex: 0 0 auto!important;
   }
+  .drawerHeader {
+    .v-list-item__content {
+      padding: 0 !important;
+    }
+  }
   .uiArrowBAckIcon {
     cursor: pointer;
     color: @btnDisableColor!important;


### PR DESCRIPTION
ISSEU: The used v-list in the drawer was adding an unneeded padding style which made the the header more bigger and not consistent with other drawers in the platform
FIX: This PR should force the v-list-content used in the header to use 0 padding syle which will keep the normal display of the drawer header