### PR TITLE
Task-55523: Fix wrong user avatar displayed in task comment

### DIFF
--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>task-management-parent</artifactId>
     <groupId>org.exoplatform.addons.task</groupId>
-    <version>3.4.x-SNAPSHOT</version>
+    <version>3.4.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>task-management-integration</artifactId>
   <packaging>jar</packaging>

--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -24,7 +24,7 @@
   <parent>
     <artifactId>task-management-parent</artifactId>
     <groupId>org.exoplatform.addons.task</groupId>
-    <version>3.4.x-SNAPSHOT</version>
+    <version>3.4.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>task-management-packaging</artifactId>
   <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
   </parent>
   <groupId>org.exoplatform.addons.task</groupId>
   <artifactId>task-management-parent</artifactId>
-  <version>3.4.x-SNAPSHOT</version>
+  <version>3.4.x-maintenance-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>eXo Add-on:: Task management</name>
   <description>Task management add-on</description>
@@ -43,9 +43,9 @@
     <url>https://github.com/exoplatform/task</url>
   </scm>
   <properties>
-    <org.exoplatform.social.version>6.4.x-SNAPSHOT</org.exoplatform.social.version>
-    <addon.exo.gamification.version>2.4.x-SNAPSHOT</addon.exo.gamification.version>
-    <addon.exo.analytics.version>1.3.x-SNAPSHOT</addon.exo.analytics.version>
+    <org.exoplatform.social.version>6.4.x-maintenance-SNAPSHOT</org.exoplatform.social.version>
+    <addon.exo.gamification.version>2.4.x-maintenance-SNAPSHOT</addon.exo.gamification.version>
+    <addon.exo.analytics.version>1.3.x-maintenance-SNAPSHOT</addon.exo.analytics.version>
 
     <!-- Sonar properties -->
     <sonar.organization>exoplatform</sonar.organization>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>task-management-parent</artifactId>
     <groupId>org.exoplatform.addons.task</groupId>
-    <version>3.4.x-SNAPSHOT</version>
+    <version>3.4.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>task-management-services</artifactId>
   <packaging>jar</packaging>

--- a/services/src/main/resources/db/changelog/task.db.changelog-1.0.0.xml
+++ b/services/src/main/resources/db/changelog/task.db.changelog-1.0.0.xml
@@ -505,4 +505,11 @@
     <createSequence sequenceName="SEQ_TASK_LABELS_LABEL_ID" startValue="1" />
   </changeSet>
 
+  <!-- Update the size of DESCRIPTION column for the table TASK_TASKS -->
+  <changeSet author="task" id="1.0.0-34">
+    <modifyDataType columnName="DESCRIPTION"
+                    newDataType="NVARCHAR(4000)"
+                    tableName="TASK_TASKS"/>
+  </changeSet>
+
 </databaseChangeLog>

--- a/task-management/pom.xml
+++ b/task-management/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <artifactId>task-management-parent</artifactId>
     <groupId>org.exoplatform.addons.task</groupId>
-    <version>3.4.x-SNAPSHOT</version>
+    <version>3.4.x-maintenance-SNAPSHOT</version>
   </parent>
   <artifactId>task-management</artifactId>
   <packaging>war</packaging>

--- a/task-management/src/main/resources/locale/portlet/taskManagement_en.properties
+++ b/task-management/src/main/resources/locale/portlet/taskManagement_en.properties
@@ -141,6 +141,7 @@ label.noAssignment=No assignment
 label.done=Done
 label.any=Any
 label.save=Save
+label.apply=Apply
 label.username=User Name
 label.firstName=First Name
 label.lastName=Last Name

--- a/task-management/src/main/webapp/skin/css/tasks.less
+++ b/task-management/src/main/webapp/skin/css/tasks.less
@@ -2686,6 +2686,31 @@
     }
   }
   .taskDescription {
+
+    .activityCharsCount{
+      position: absolute;
+      bottom: 3px;
+      font-size: 15px;
+      right: 10px ~'; /** orientation=lt */ ';
+      left: 3px ~'; /** orientation=rt */ ';
+      color: #adadad;
+
+      .uiIconMessageLength {
+        font-size: 14px;
+        color: #2eb58c;
+        &:before {
+          content: "\e910";
+        }
+      }
+    }
+
+    .tooManyChars {
+      color: #bc4343!important;
+    }
+    .tooManyChars .uiIconMessageLength {
+      color: #bc4343!important;
+    }
+
     ul li {
       list-style-position: inside;
       list-style-type: disc;
@@ -2713,13 +2738,6 @@
       border-left: none ~'; /** orientation=rt */ ';
     }
 
-    .activityCharsCount.tooManyChars {
-      display: none;
-      /*position: absolute;
-      bottom: 8px;
-      right: 10px;
-      color: @greyColorLighten1;*/
-    }
     .cke_bottom.cke_reset_all {
       background-color: transparent;
       height: 30px!important;

--- a/task-management/src/main/webapp/skin/css/tasks.less
+++ b/task-management/src/main/webapp/skin/css/tasks.less
@@ -2688,10 +2688,10 @@
   .taskDescription {
 
     .activityCharsCount{
-      position: absolute;
-      bottom: 3px;
+      position: relative;
+      bottom: 25px;
       font-size: 15px;
-      right: 10px ~'; /** orientation=lt */ ';
+      right: 3px ~'; /** orientation=lt */ ';
       left: 3px ~'; /** orientation=rt */ ';
       color: #adadad;
 

--- a/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawer.vue
+++ b/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawer.vue
@@ -273,7 +273,7 @@ export default {
     },
     taskDescriptionValid() {
       const taskDescriptionText = this.$utils.htmlToText(this.taskDescription);
-      return !taskDescriptionText || taskDescriptionText.length < 2000;
+      return !taskDescriptionText || taskDescriptionText.length <= 2000;
     },
     disableSaveButton() {
       return this.saving || !this.taskTitleValid || !this.taskDescriptionValid;

--- a/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawer.vue
+++ b/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawer.vue
@@ -32,7 +32,7 @@
       right
       @closed="onCloseDrawer">
       <template 
-        v-if="task.id!=null" 
+        v-if="task.id" 
         slot="title">
         <div class="drawerTitleAndProject d-flex">
           <i
@@ -93,17 +93,17 @@
             </v-btn>
             <v-textarea
               ref="autoFocusInput4"
-              v-model="task.title"
+              v-model="taskTitle"
               :class="{taskCompleted: task.completed}"
               :placeholder="$t('label.tapTask.name')"
-              :autofocus="task && task.id === null"
+              :autofocus="!task || !task.id"
               type="text"
               class="ps-0 pt-0 task-name"
               auto-grow
               rows="1"
               row-height="13"
               required
-              @change="updateTaskTitle()" />
+              @change="updateTaskTitle" />
           </div>
           <div
             v-if="task && task && task.id"
@@ -145,9 +145,8 @@
           <v-divider class="my-0" />
           <div class="taskDescription py-4">
             <task-description-editor
+              v-model="taskDescription"
               :task="task"
-              v-model="task.description"
-              :value="task.description"
               :placeholder="$t('editinline.taskDescription.empty')"
               @addTaskDescription="addTaskDescription($event)" />
           </div>
@@ -169,7 +168,7 @@
             class="d-flex" />
           <v-divider class="my-0" />
           <v-flex
-            v-if="task.id!=null"
+            v-if="task.id"
             xs12
             class="pt-2 taskCommentsAndChanges">
             <task-view-all-comments
@@ -228,7 +227,6 @@ export default {
       chips: [],
       autoSaveDelay: 1000,
       saveDescription: '',
-      taskTitle_: '',
       logs: [],
       comments: [],
       subEditorIsOpen: false,
@@ -244,7 +242,7 @@ export default {
       enableDelete: false,
       enableClone: false,
       currentUserName: eXo.env.portal.userName,
-      MESSAGE_MAX_LENGTH: 1250,
+      MESSAGE_MAX_LENGTH: 2000,
       dateTimeFormat: {
         year: 'numeric',
         month: 'long',
@@ -256,6 +254,8 @@ export default {
       oldTask: {},
       showBackArrow: false,
       taskSpace: {},
+      taskTitle: null,
+      taskDescription: null,
     };
   },
   computed: {
@@ -268,14 +268,15 @@ export default {
       }
       return `${eXo.env.portal.context}/${eXo.env.portal.portalName}/tasks/taskDetail/${this.task.id}`;
     },
-    taskTitle() {
-      return this.task && this.task.title;
-    },
     taskTitleValid() {
-      return this.taskTitle && this.taskTitle.trim() && this.taskTitle.trim().length >= 3 && this.taskTitle.length < 1024;
+      return  this.taskTitle?.trim().length >= 3 && this.taskTitle.length < 1024;
+    },
+    taskDescriptionValid() {
+      const taskDescriptionText = this.$utils.htmlToText(this.taskDescription);
+      return !taskDescriptionText || taskDescriptionText.length < 2000;
     },
     disableSaveButton() {
-      return this.saving || !this.taskTitleValid;
+      return this.saving || !this.taskTitleValid || !this.taskDescriptionValid;
     },
     lastTaskChangesLog() {
       return this.logs && this.logs.length && this.logs[0].createdTime || '';
@@ -347,6 +348,7 @@ export default {
     document.removeEventListener('keyup', this.escapeKeyListener);
   },
   methods: {
+
     closePriority() {
       document.dispatchEvent(new CustomEvent('closePriority'));
     },
@@ -366,23 +368,23 @@ export default {
       document.dispatchEvent(new CustomEvent('closeAssignments'));
     },
     updateTaskTitle() {
-      if (this.oldTask.title!==this.task.title){
-        if (!this.task.title || this.task.title.length===0 ){
+      if (this.task.id && this.oldTask.title !== this.taskTitle) {
+        if (!this.taskTitle || !this.taskTitle.length) {
           this.$root.$emit('show-alert', {type: 'error',message: this.$t('alert.error.title.mandatory')});
-        } else if (!this.taskTitleValid){
+        } else if (!this.taskTitleValid) {
           this.$root.$emit('show-alert', {type: 'error',message: this.$t('alert.error.title.length')});
-        } else if (this.task.id != null) {
-          this.$taskDrawerApi.updateTask(this.task.id, this.task).then(() => {
-            this.taskTitle_ = this.task.title;
-            this.oldTask.title = this.task.title;
-            this.$root.$emit('task-updated', this.task);
-            this.$root.$emit('show-alert', {
-              type: 'success',
-              message: this.$t('alert.success.task.title')
-            });
-          })
-            .catch(e => {
-              this.task.title = this.taskTitle_;
+        } else {
+          const task = JSON.parse(JSON.stringify(this.task));
+          task.title = this.taskTitle;
+          this.$taskDrawerApi.updateTask(this.task.id, task)
+            .then(() => {
+              this.task.title = this.oldTask.title = this.taskTitle;
+              this.$root.$emit('show-alert', {
+                type: 'success',
+                message: this.$t('alert.success.task.title')
+              });
+              this.$root.$emit('task-updated', JSON.parse(JSON.stringify(this.task)));
+            }).catch(e => {
               console.error('Error when updating task\'s title', e);
               this.$root.$emit('show-alert', {
                 type: 'error',
@@ -390,6 +392,8 @@ export default {
               });
             });
         }
+      } else if (!this.task.id) {
+        this.task.title = this.oldTask.title = this.taskTitle;
       }
     },
     updateCompleted() {
@@ -537,6 +541,7 @@ export default {
     },
     addTask() {
       document.dispatchEvent(new CustomEvent('onAddTask'));
+      this.task.description = this.taskDescription;
       this.task.coworker = this.taskCoworkers;
       this.task.assignee = this.assignee;
       this.task.startDate = this.taskStartDate;
@@ -653,9 +658,10 @@ export default {
       window.open(`${ eXo.env.portal.context }/${ eXo.env.portal.portalName }/${ pagelink }`, '_blank');
     },
     open(task) {
-      this.oldTask= Object.assign({}, task);
-      this.taskTitle_= task.title;
-      this.task = task;
+      this.oldTask = task;
+      this.task = JSON.parse(JSON.stringify(task));
+      this.taskTitle = this.task.title;
+      this.taskDescription = this.task.description;
       this.taskCoworkers= null;
       this.assignee= null;
       this.taskStartDate= null;
@@ -702,7 +708,6 @@ export default {
       this.$refs.addTaskDrawer.close();
     },
     onCloseDrawer() {
-      this.task.title = this.taskTitle_;
       this.$root.$emit('task-drawer-closed', this.task);
       this.showEditor = false;
       this.task = {};

--- a/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawer.vue
+++ b/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawer.vue
@@ -711,6 +711,7 @@ export default {
       this.$root.$emit('task-drawer-closed', this.task);
       this.showEditor = false;
       this.task = {};
+      this.comments = {};
       this.$root.$emit('drawerClosed');
       document.dispatchEvent(new CustomEvent('loadTaskLabels', {
         detail: {}

--- a/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskDescriptionEditor.vue
+++ b/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskDescriptionEditor.vue
@@ -94,7 +94,7 @@ export default {
       return pureText.length;
     },
     saveDescriptionButtonDisabled() {
-      return this.savingDescription || this.inputVal?.length > this.MESSAGE_MAX_LENGTH;
+      return this.savingDescription || this.charsCount > this.MESSAGE_MAX_LENGTH;
     },
     taskDescription() {
       return this.task?.description || '';

--- a/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskDescriptionEditor.vue
+++ b/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskDescriptionEditor.vue
@@ -25,17 +25,38 @@
       contentEditable="true"
       class="py-1 px-2 taskDescriptionToShow"
       @click="showDescriptionEditor($event)"
-      v-html="inputVal ? urlVerify(inputVal) : inputVal">
+      v-sanitized-html="value">
       {{ placeholder }}
     </div>
 
-    <exo-task-editor
-      v-if="displayEditor"
-      ref="richEditor"
-      v-model="inputVal"
-      :max-length="MESSAGE_MAX_LENGTH"
-      :id="task.id"
-      :placeholder="$t('task.placeholder').replace('{0}', MESSAGE_MAX_LENGTH)" />
+    <textarea
+      id="descriptionContent"
+      ref="editor"
+      v-model="value"
+      class="d-none"
+      cols="30"
+      rows="10"></textarea>
+
+    <div
+      v-if="displayEditor && editorReady"
+      :class="charsCount > MESSAGE_MAX_LENGTH ? 'tooManyChars' : ''"
+      class="activityCharsCount flex d-flex justify-end"
+      style="">
+      {{ charsCount }}/{{ MESSAGE_MAX_LENGTH }}
+      <i class="uiIconMessageLength"></i>
+    </div>
+
+    <v-btn
+      v-if="task.id && displayEditor && editorReady"
+      id="saveDescriptionButton"
+      :loading="savingDescription"
+      :disabled="saveDescriptionButtonDisabled"
+      depressed
+      outlined
+      class="btn mt-1 ml-auto d-flex px-2 btn-primary v-btn v-btn--contained theme--light v-size--default"
+      @click="saveDescription">
+      {{ $t('label.apply') }}
+    </v-btn>
 
   </div>
 </template>
@@ -46,10 +67,6 @@ export default {
     value: {
       type: String,
       default: ''
-    },
-    reset: {
-      type: Boolean,
-      default: false
     },
     placeholder: {
       type: String,
@@ -65,18 +82,27 @@ export default {
   data() {
     return {
       MESSAGE_MAX_LENGTH: 2000,
-      inputVal: this.value,
+      inputVal: '',
       editorReady: false,
       showEditor: false,
+      savingDescription: false,
     };
   },
   computed: {
-    taskDescription () {
-      return this.task && this.task.id && this.task.description || '';
+    charsCount() {
+      const pureText = this.$utils.htmlToText(this.value);
+      return pureText.length;
+    },
+    saveDescriptionButtonDisabled() {
+      return this.savingDescription || this.inputVal?.length > this.MESSAGE_MAX_LENGTH;
+    },
+    taskDescription() {
+      return this.task?.description || '';
     },
     displayEditor() {
       return this.showEditor;
-    }
+    },
+
   },
   watch: {
     inputVal(val) {
@@ -89,9 +115,9 @@ export default {
           CKEDITOR.instances['descriptionContent'].setData(val);
         }
       }
-    },
-    value() {
-      this.inputVal = this.taskDescription;
+      if (this.editorReady) {
+        this.$emit('input', val);
+      }
     },
     editorReady(val) {
       const ckeContent = document.querySelectorAll('[id=cke_descriptionContent]');
@@ -103,52 +129,54 @@ export default {
           }
         }
         document.getElementById('taskDescriptionId').classList.remove('taskDescription');
-        CKEDITOR.instances['descriptionContent'].focus(true);
+        if (CKEDITOR.instances['descriptionContent']) {
+          CKEDITOR.instances['descriptionContent'].focus(true);
+        }
       } else {
         for (let i = 0; i < ckeContent.length; i++) {
           ckeContent[i].classList.add('hiddenEditor');
           document.getElementById('taskDescriptionId').classList.add('taskDescription');
         }
       }
-      this.saveDescription(this.inputVal);
     },
     reset() {
-      CKEDITOR.instances['descriptionContent'].destroy(true);
-      this.editorReady = false;
+      this.hideDescriptionEditor();
     },
   },
   created() {
     this.$root.$off('drawerClosed');
     this.$root.$on('drawerClosed', () => {
-      this.saveDescription(this.inputVal);
-      this.editorReady = false;
+      this.hideDescriptionEditor();
     });
     document.addEventListener('onAddTask', () => {
       this.$emit('addTaskDescription',this.inputVal);
-      this.editorReady = false;
+      this.hideDescriptionEditor();
     });
+    this.inputVal = this.value || '';
   },
   methods: {
-    saveDescription: function (newValue) {
-      if (newValue){
-        newValue = newValue.replace('&nbsp;',' ');
-      }
-      if (newValue !== this.taskDescription && newValue !== this.task.description) {
-        if (this.task.id && !isNaN(this.task.id)){
-          this.task.description = newValue;
-          this.$taskDrawerApi.updateTask(this.task.id ,this.task)
-            .then( () => {
-              this.$root.$emit('show-alert', {
-                type: 'success',
-                message: this.$t('alert.success.task.description')
-              });
-              this.$root.$emit('task-description-updated', this.task);
-            }).catch(e => {
-              console.error('Error when updating task\'s descriprion', e);
-              this.$root.$emit('show-alert',{type: 'error',message: this.$t('alert.error')} );
+    saveDescription() {
+      const newValue = this.inputVal?.replace('&nbsp;',' ');
+      if (this.task.id && !isNaN(this.task.id)) {
+        this.savingDescription = true;
+
+        const task = JSON.parse(JSON.stringify(this.task));
+        task.description = newValue;
+        this.$taskDrawerApi.updateTask(this.task.id , task)
+          .then(() => {
+            this.task.description = newValue;
+            this.$root.$emit('show-alert', {
+              type: 'success',
+              message: this.$t('alert.success.task.description')
             });
-        }
-        //this.inputVal = '';
+            this.$root.$emit('task-description-updated', this.task);
+            this.hideDescriptionEditor();
+          }).catch(() => {
+            this.$root.$emit('show-alert',{
+              type: 'error',
+              message: this.$t('alert.error')
+            });
+          }).finally(() => this.savingDescription = false);
       }
     },
     initCKEditor: function () {
@@ -163,7 +191,6 @@ export default {
       const self = this;
       $(this.$refs.editor).ckeditor({
         customConfig: '/commons-extension/ckeditorCustom/config.js',
-        //removePlugins: 'suggester,simpleLink,confighelper',
         extraPlugins: extraPlugins,
         removePlugins: 'confirmBeforeReload,maximize,resize',
         toolbarLocation: 'bottom',
@@ -172,27 +199,34 @@ export default {
         on: {
           blur: function () {
             $(document.body).trigger('click');
-            self.editorReady = false;
+            self.hideDescriptionEditor();
           },
           change: function(evt) {
             const newData = evt.editor.getData();
             self.inputVal = newData;
           },
           destroy: function () {
-            self.inputVal = '';
             self.editorReady = false;
+            self.showEditor = false;
+            self.inputVal = '';
           }
         },
       });
     },
+    hideDescriptionEditor() {
+      if (CKEDITOR.instances['descriptionContent']) {
+        CKEDITOR.instances['descriptionContent'].destroy(true);
+      }
+      this.editorReady = false;
+      this.showEditor = false;
+    },
     showDescriptionEditor: function (event) {
-      this.showEditor = !this.showEditor;
-      const target = $( event.target );
-      if ( target.is( 'a' ) ) {
-        const url = target[0].href;
-        window.open(url, '_blank');
-      } else {
-        this.editorReady = !this.editorReady;
+      if (!this.showEditor && event?.target?.nodeName !== 'A') {
+        this.inputVal = this.value;
+        this.editorReady = true;
+        this.showEditor = true;
+      } else if (event?.target?.nodeName === 'A') {
+        window.open(event.target.href, '_blank');
       }
     },
     urlVerify(text) {

--- a/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskDescriptionEditor.vue
+++ b/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskDescriptionEditor.vue
@@ -28,13 +28,15 @@
       v-html="inputVal ? urlVerify(inputVal) : inputVal">
       {{ placeholder }}
     </div>
-    <textarea
-      id="descriptionContent"
-      ref="editor"
+
+    <exo-task-editor
+      v-if="displayEditor"
+      ref="richEditor"
       v-model="inputVal"
-      class="d-none"
-      cols="30"
-      rows="10"></textarea>
+      :max-length="MESSAGE_MAX_LENGTH"
+      :id="task.id"
+      :placeholder="$t('task.placeholder').replace('{0}', MESSAGE_MAX_LENGTH)" />
+
   </div>
 </template>
 
@@ -62,13 +64,18 @@ export default {
   },
   data() {
     return {
+      MESSAGE_MAX_LENGTH: 2000,
       inputVal: this.value,
-      editorReady: false
+      editorReady: false,
+      showEditor: false,
     };
   },
   computed: {
     taskDescription () {
       return this.task && this.task.id && this.task.description || '';
+    },
+    displayEditor() {
+      return this.showEditor;
     }
   },
   watch: {
@@ -179,6 +186,7 @@ export default {
       });
     },
     showDescriptionEditor: function (event) {
+      this.showEditor = !this.showEditor;
       const target = $( event.target );
       if ( target.is( 'a' ) ) {
         const url = target[0].href;

--- a/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskFormDatePickers.vue
+++ b/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskFormDatePickers.vue
@@ -222,12 +222,12 @@ export default {
         this.dueDate = null;
         if (this.actualTask.startDate!=null) {
           this.$nextTick().then(() => {
-            this.startDate = this.toDate(this.actualTask.startDate.time);
+            this.startDate = this.toDate(this.actualTask.startDate);
           });
         }
         if (this.actualTask.dueDate!=null) {
           this.$nextTick().then(() => {
-            this.dueDate = this.toDate(this.actualTask.dueDate.time);
+            this.dueDate = this.toDate(this.actualTask.dueDate);
           });
         }
       } else {
@@ -246,7 +246,8 @@ export default {
         }
         return new Date(date);
       } else if (typeof date === 'object') {
-        return new Date(date);
+        const formattedDate = `${date.year + 1900}-${date.month + 1}-${date.date}`;
+        return new Date(formattedDate);
       }
     },
     toDateObject(date) {

--- a/task-management/src/main/webapp/vue-app/tasks-management/components/Project/ExoTaskEditor.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/Project/ExoTaskEditor.vue
@@ -60,25 +60,29 @@ export default {
     maxLength: {
       type: Number,
       default: -1
-    }
+    },
   },
   data() {
     return {
       SMARTPHONE_LANDSCAPE_WIDTH: 768,
       descriptionTaskContent: '',
       inputVal: this.value,
-      charsCount: 0,
       editorReady: false,
     };
+  },
+  computed: {
+    charsCount() {
+      const pureText = this.$utils.htmlToText(this.inputVal);
+      return pureText.length;
+    },
   },
   watch: {
     inputVal(val) {
       this.$emit('input', val);
     },
     value(val) {
-
       for (const instances in CKEDITOR.instances){
-        if (CKEDITOR.instances[instances].element.$.id===this.descriptionTaskContent){
+        if (CKEDITOR.instances[instances].element.$.id === this.descriptionTaskContent) {
           const editorData = CKEDITOR.instances[instances].getData();
           // watch value to reset the editor value if the value has been updated by the component parent
           if (editorData != null && val !== editorData) {
@@ -91,7 +95,6 @@ export default {
           }
         }
       }
-
     },
     reset() {
       CKEDITOR.instances[this.descriptionTaskContent].destroy(true);
@@ -139,18 +142,10 @@ export default {
           },
           change: function(evt) {
             const newData = evt.editor.getData();
-
             self.inputVal = newData;
-
-            let pureText = newData ? newData.replace(/<[^>]*>/g, '').replace(/&nbsp;/g, '').trim() : '';
-            const div = document.createElement('div');
-            div.innerHTML = pureText;
-            pureText = div.textContent || div.innerText || '';
-            self.charsCount = pureText.length;
           },
           destroy: function () {
             self.inputVal = '';
-            self.charsCount = 0;
           }
         }
       });

--- a/task-management/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TaskViewCard.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TaskViewCard.vue
@@ -183,6 +183,11 @@ export default {
     },
   },
   created() {
+    this.$root.$on('task-updated', task => {
+      if (this.task?.task?.id === task?.id) {
+        this.task.task = task;
+      }
+    });
     this.$root.$on('update-completed-task', (value, id) => {
       if (this.task.id === id) {
         this.task.task.completed = value;

--- a/task-management/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TaskViewCard.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TaskViewCard.vue
@@ -137,8 +137,12 @@ export default {
     };
   },
   computed: {
-    taskDueDate() {
-      return this.task && this.task.task.dueDate && this.task.task.dueDate.time;
+    taskDueDate() { 
+      if (this.task?.task?.dueDate?.time) {
+        const formattedDate = `${this.task.task.dueDate.year + 1900}-${this.task.task.dueDate.month + 1}-${this.task.task.dueDate.date}`;
+        return new Date(formattedDate);
+      }
+      return null;
     },
     avatarToDisplay () {
       const usersList = [];
@@ -350,8 +354,7 @@ export default {
         const day = date.getDate();
         const month = date.getMonth()+1;
         const year = date.getFullYear();
-        const formattedTime = `${  year}-${  month  }-${day  }`;
-        return formattedTime;
+        return `${year}-${month}-${day}`;
       }
     },
     getOverdueTask(value){

--- a/task-management/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TasksViewGantt.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TasksViewGantt.vue
@@ -108,7 +108,9 @@ export default {
       const tasksInGantt = this.getTasksToDisplay(taskItems);
       if ( this.tasksToDisplay && this.tasksToDisplay.length && tasksInGantt.length > this.tasksToDisplay.length) {
         this.tasksToDisplay.push(tasksInGantt[tasksInGantt.length-1]);
-        this.gantt.refresh(this.tasksToDisplay);
+        if (this.gantt) {
+          this.gantt.refresh(this.tasksToDisplay);
+        }
       }
       this.$root.$emit('refresh-unscheduled-gantt',this.unscheduledTaskList);
     });
@@ -122,7 +124,11 @@ export default {
       this.tasksToDisplay = this.getTasksToDisplay(this.tasks);
       this.$root.$emit('refresh-unscheduled-gantt',this.unscheduledTaskList);
       if (this.ganttTasks > 0 ) {
-        this.gantt.refresh(this.tasksToDisplay);
+        this.$nextTick().then(() => {
+          if (this.gantt) {
+            this.gantt.refresh(this.tasksToDisplay);
+          }
+        });
       }
     });
   },

--- a/task-management/src/main/webapp/vue-app/tasks-management/components/tasks/TaskCard.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/tasks/TaskCard.vue
@@ -168,6 +168,11 @@ export default {
     },
   },
   created() {
+    this.$root.$on('task-updated', task => {
+      if (this.task?.task?.id === task?.id) {
+        this.task.task = task;
+      }
+    });
     this.$root.$on('update-completed-task', (value, id) => {
       if (this.task.id === id) {
         this.task.task.completed = value;

--- a/task-management/src/main/webapp/vue-app/tasks-management/components/tasks/TasksListItem.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/tasks/TasksListItem.vue
@@ -197,6 +197,11 @@ export default {
     },
   },
   created() {
+    this.$root.$on('task-updated', task => {
+      if (this.task?.task?.id === task?.id) {
+        this.task.task = task;
+      }
+    });
     this.$root.$on('update-completed-task',(value,id)=>{
       if (this.task.id === id){
         this.task.task.completed=value;

--- a/task-management/src/main/webapp/vue-app/tasks/components/TaskDetails.vue
+++ b/task-management/src/main/webapp/vue-app/tasks/components/TaskDetails.vue
@@ -100,6 +100,13 @@ export default {
       return `${this.task.status.project.color  }_border`;
     }
   },
+  created() {
+    this.$root.$on('task-updated', task => {
+      if (this.task?.task?.id === task?.id) {
+        this.task.task = task;
+      }
+    });
+  },
   methods: {
     dateFormatter(dueDate) {
       if (dueDate) {


### PR DESCRIPTION
Before this fix,  when a user opens a Task A that has a comment by a user A, then he opens another Task B with a comment by a user B. The user displays the User A name and avatar in the task B Instead of displaying the User B name and avatar.
Fix: When the user closes a task drawer, comments array is cleaned in order to avoid using comment details of the current Task in another one.