### PR TITLE
Task-55523: Fix wrong user avatar displayed in task comment

### DIFF
--- a/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawer.vue
+++ b/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawer.vue
@@ -711,6 +711,7 @@ export default {
       this.$root.$emit('task-drawer-closed', this.task);
       this.showEditor = false;
       this.task = {};
+      this.comments = {};
       this.$root.$emit('drawerClosed');
       document.dispatchEvent(new CustomEvent('loadTaskLabels', {
         detail: {}


### PR DESCRIPTION
Before this fix, when a user opens a Task A that has a comment by a user A, then he opens another Task B with a comment by a user B. The user displays the User A name and avatar in the task B Instead of displaying the User B name and avatar.
Fix: When the user closes a task drawer, comments array is cleaned in order to avoid using comment details of the current Task in another one.