### PR TITLE
Task-57032: columns in tasks board are now draggable ony by the column header

### DIFF
--- a/task-management/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TasksViewBoard.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TasksViewBoard.vue
@@ -29,7 +29,9 @@
               ghost-class="ghost-card"
               class="d-flex"
               @start="dragStatus=true"
-              @end="dragStatus=false">
+              @end="dragStatus=false"
+              :options="{handle:'.draggHandler'}"
+              >
               <v-col
                 v-for="(status, index) in statusList"
                 :key="index"

--- a/task-management/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TasksViewBoard.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TasksViewBoard.vue
@@ -30,8 +30,7 @@
               class="d-flex"
               @start="dragStatus=true"
               @end="dragStatus=false"
-              :options="{handle:'.draggHandler'}"
-              >
+              :options="{handle:'.draggHandler'}">
               <v-col
                 v-for="(status, index) in statusList"
                 :key="index"

--- a/task-management/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TasksViewBoardColumn.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TasksViewBoardColumn.vue
@@ -17,6 +17,7 @@
 <template>
   <div :id="status.id">
     <tasks-view-header
+      class="draggHandler"
       :status="status"
       :project="project"
       :view-type="'board'"


### PR DESCRIPTION
ISSUE: The columns in the tasks board can be dragged by selecting anywhere in the column and dragging.
FIX: The columns in the tasks board can be dragged only by selecting the column header (the row that specify the column state) and dragging.