### PR TITLE
TASK-57108: Updating task project is not working after completely remove the old parent project

### DIFF
--- a/services/src/main/java/org/exoplatform/task/rest/TaskRestService.java
+++ b/services/src/main/java/org/exoplatform/task/rest/TaskRestService.java
@@ -443,7 +443,10 @@ public class TaskRestService implements ResourceContainer {
     if (task == null) {
       return Response.status(Response.Status.NOT_FOUND).build();
     }
-    if (!TaskUtil.hasEditPermission(taskService,task)) {
+    if (task.getStatus() == null) {
+      task.setStatus(updatedTask.getStatus());
+    }
+    if (!TaskUtil.hasEditPermission(taskService, task)) {
       return Response.status(Response.Status.FORBIDDEN).build();
     }
     task = taskService.updateTask(updatedTask);


### PR DESCRIPTION
Prior to this change, when removing a task form a project, the task status object is also removed, because it's the old default status object of the old project, and when you want to add a new project while the current task has a null status object, there will be a fail while checking the permission on the new task project for the reason that the task still didn't get updated and has no status abject and so inability to check permission which will cause a unauthorized exception because the only way here to get the project is through the status object.
This PR set the new added status of the updated task to the current returned task before checking the permission on the project via TaskUtil.hasEditPermission to allow a correct check