### PR TITLE
Task-56626: all opened drawers are closed when we click outside #63

### DIFF
--- a/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawer.vue
+++ b/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawer.vue
@@ -318,12 +318,6 @@ export default {
         }, 200);
       }
     });
-    $(document).on('click', (event) => {
-      if (( event.target.className === 'v-overlay__scrim' ) && ( this.isDrawerClose )) {
-        this.$refs.addTaskDrawer.close();
-      }
-    });
-
     document.addEventListener('labelListChanged', event => {
       if (event && event.detail) {
         const label = event.detail;


### PR DESCRIPTION
ISSUE: when an task drawer is opened and we click outside the drawer on the gray screen (DrawerOverlay component) we call a method to explicitly close the task drawer (the ref for this drawer is addTaskDrawer for an already existing drawer or when we want to add a new task).
This behavior introduces a regression when we have multiple drawers opened and we click outside, in this case all drawer will be closed

FIX: remove the code that explicitly closes the addTaskDrawer when we click outside.
For this fix the behavior will be to close only the top drawer when we click outside