### PR TITLE
TASK-57394 Fix Drawer overlay deletion when confirm dialog gets closed

### DIFF
--- a/task-management/src/main/webapp/js/taskDrawerApi.js
+++ b/task-management/src/main/webapp/js/taskDrawerApi.js
@@ -132,10 +132,10 @@ export function addTaskToLabel(taskId, label) {
 export function removeTaskFromLabel(taskId, labelId) {
   return fetch(`/portal/rest/tasks/labels/${taskId}/${labelId}`, {
     credentials: 'include',
-    method: 'delete',
+    method: 'DELETE',
   }).then((resp) => {
     if (resp && resp.ok) {
-      return resp;
+      return;
     } else {
       throw new Error('Error when deleting task from label');
     }
@@ -181,10 +181,10 @@ export function editLabel(label) {
 export function removeLabel(labelId) {
   return fetch(`/portal/rest/tasks/labels/${labelId}`, {
     credentials: 'include',
-    method: 'delete',
+    method: 'DELETE',
   }).then((resp) => {
     if (resp && resp.ok) {
-      return resp;
+      return;
     } else {
       throw new Error('Error when deleting label');
     }
@@ -307,11 +307,11 @@ export function addTaskSubComment(taskId, parentCommentId, comment) {
 
 export function removeTaskComment(commentId) {
   return fetch(`/portal/rest/tasks/comments/${commentId}`, {
-    method: 'delete',
+    method: 'DELETE',
     credentials: 'include',
   }).then((resp) => {
     if (resp && resp.ok) {
-      return resp.json();
+      return;
     } else {
       throw new Error('Error when removing task comment');
     }

--- a/task-management/src/main/webapp/vue-app/taskCommentsDrawer/components/TaskComments.vue
+++ b/task-management/src/main/webapp/vue-app/taskCommentsDrawer/components/TaskComments.vue
@@ -121,20 +121,22 @@ export default {
       }
     },
     removeTaskComment() {
-      this.$taskDrawerApi.removeTaskComment(this.commentToDelete);
-      this.comments.forEach((comment,index) => {
-        if ( comment === this.comment) {
-          if ( this.comment.comment.id === this.commentToDelete ) {
-            this.comments.splice(index, 1);
-          } else {
-            comment.subComments.forEach((subComment,index) => {
-              if ( subComment.comment.id === this.commentToDelete) {
-                this.comment.subComments.splice(index,1);
+      this.$taskDrawerApi.removeTaskComment(this.commentToDelete)
+        .then(() => {
+          this.comments.forEach((comment,index) => {
+            if ( comment === this.comment) {
+              if ( this.comment.comment.id === this.commentToDelete ) {
+                this.comments.splice(index, 1);
+              } else {
+                comment.subComments.forEach((subComment,index) => {
+                  if ( subComment.comment.id === this.commentToDelete) {
+                    this.comment.subComments.splice(index,1);
+                  }
+                });
               }
-            });
-          }
-        }
-      });
+            }
+          });
+        });
       this.$emit('confirmDialogClosed');
     },
     displayCommentDate(dateTimeValue) {

--- a/task-management/src/main/webapp/vue-app/tasks-management/main.js
+++ b/task-management/src/main/webapp/vue-app/tasks-management/main.js
@@ -57,6 +57,9 @@ const lang = eXo && tasksConstants.LANG || 'en';
 //should expose the locale ressources as REST API
 const url = `${tasksConstants.PORTAL}/${tasksConstants.PORTAL_REST}/i18n/bundle/locale.portlet.taskManagement-${lang}.json`;
 
+//used only in mobile statistics
+eXo.env.portal.mainApplicationName = 'Tasks';
+
 export function init() {
   exoi18n.loadLanguageAsync(lang, url).then(i18n => {
     // init Vue app when locale ressources are ready

--- a/task-management/src/main/webapp/vue-app/tasks-management/main.js
+++ b/task-management/src/main/webapp/vue-app/tasks-management/main.js
@@ -57,9 +57,6 @@ const lang = eXo && tasksConstants.LANG || 'en';
 //should expose the locale ressources as REST API
 const url = `${tasksConstants.PORTAL}/${tasksConstants.PORTAL_REST}/i18n/bundle/locale.portlet.taskManagement-${lang}.json`;
 
-//used only in mobile statistics
-eXo.env.portal.mainApplicationName = 'Tasks';
-
 export function init() {
   exoi18n.loadLanguageAsync(lang, url).then(i18n => {
     // init Vue app when locale ressources are ready


### PR DESCRIPTION
ISSUE: when we delete a comment from a task drawer the gray screen overlaying the project board gets removed
FIX: remove the task comment from UI only when the Fetch REST API call gets resolved successfully.