### PR TITLE
Task-54760: Status of task on list view is always in English

### DIFF
--- a/task-management/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TasksViewHeaderStatus.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TasksViewHeaderStatus.vue
@@ -48,7 +48,7 @@
       <div
         v-else
         class="text-truncate subtitle-2 text-color my-auto">
-        {{ status.name }} <span class="text-truncate subtitle-2 text-color my-auto">({{ tasksNumber }})</span>
+        {{ taskStatusLabel }} <span class="text-truncate subtitle-2 text-color my-auto">({{ tasksNumber }})</span>
       </div>
     </div>
     <v-divider class="mx-1" />
@@ -143,7 +143,21 @@ export default {
     },
     limitTasksToshow() {
       return this.tasksStatsStartValue;
-    }
+    },
+    taskStatusLabel() {
+      switch (this.status && this.status.name) {
+      case 'ToDo':
+        return this.$t('exo.tasks.status.todo');
+      case 'InProgress':
+        return this.$t('exo.tasks.status.inprogress');
+      case 'WaitingOn':
+        return this.$t('exo.tasks.status.waitingon');
+      case 'Done':
+        return this.$t('exo.tasks.status.done');
+      default:
+        return this.status.name;
+      }
+    },
   },
   created() {
     $(document).on('mousedown', () => {

--- a/task-management/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TasksViewHeaderStatus.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TasksViewHeaderStatus.vue
@@ -147,8 +147,7 @@ export default {
     taskStatusLabel() {
       const key = `exo.tasks.status.${this.status?.name.toLowerCase()}`;
       const translatedLabel = this.$t(key);
-      const label = translatedLabel === key && this.status?.name || translatedLabel;
-      return label;
+      return translatedLabel === key && this.status?.name || translatedLabel;
     }
   },
   created() {

--- a/task-management/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TasksViewHeaderStatus.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TasksViewHeaderStatus.vue
@@ -145,19 +145,11 @@ export default {
       return this.tasksStatsStartValue;
     },
     taskStatusLabel() {
-      switch (this.status && this.status.name) {
-      case 'ToDo':
-        return this.$t('exo.tasks.status.todo');
-      case 'InProgress':
-        return this.$t('exo.tasks.status.inprogress');
-      case 'WaitingOn':
-        return this.$t('exo.tasks.status.waitingon');
-      case 'Done':
-        return this.$t('exo.tasks.status.done');
-      default:
-        return this.status.name;
-      }
-    },
+      const key = `exo.tasks.status.${this.status?.name.toLowerCase()}`;
+      const translatedLabel = this.$t(key);
+      const label = translatedLabel === key && this.status?.name || translatedLabel;
+      return label;
+    }
   },
   created() {
     $(document).on('mousedown', () => {


### PR DESCRIPTION
Problem: Status of tasks are always in English when displayed in another language
Fix: use translation when available, else display the Task Status name as it is