### PR TITLE
TASK-56897: fix task start and due date on safari

### DIFF
--- a/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskFormDatePickers.vue
+++ b/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskFormDatePickers.vue
@@ -220,14 +220,14 @@ export default {
       if (this.actualTask.id!=null) {
         this.startDate = null;
         this.dueDate = null;
-        if (this.actualTask.startDate!=null) {
+        if (this.actualTask.startDate) {
           this.$nextTick().then(() => {
-            this.startDate = this.toDate(this.actualTask.startDate);
+            this.startDate = this.toDate(this.actualTask.startDate.time);
           });
         }
-        if (this.actualTask.dueDate!=null) {
+        if (this.actualTask.dueDate) {
           this.$nextTick().then(() => {
-            this.dueDate = this.toDate(this.actualTask.dueDate);
+            this.dueDate = this.toDate(this.actualTask.dueDate.time);
           });
         }
       } else {


### PR DESCRIPTION
ISSUE: after selecting a start and due date for a task on safari, these dates will not show up the next time we open the task drawer
FIX: when opening the task drawer the start and due date don't get initialized properly due to problems with the Date object constructor on safari.
the fix is to simply use the time-stamps to create these date objects