### PR TITLE
TASK-57812 Fix Task Description CKEditor buttons usage

### DIFF
--- a/task-management/src/main/webapp/skin/css/tasks.less
+++ b/task-management/src/main/webapp/skin/css/tasks.less
@@ -2686,13 +2686,14 @@
     }
   }
   .taskDescription {
+    position: relative;
 
     .activityCharsCount{
-      position: relative;
-      bottom: 25px;
+      position: absolute;
+      bottom: 47px;
       font-size: 15px;
-      right: 3px ~'; /** orientation=lt */ ';
-      left: 3px ~'; /** orientation=rt */ ';
+      right: 5px ~'; /** orientation=lt */ ';
+      left: 5px ~'; /** orientation=rt */ ';
       color: #adadad;
 
       .uiIconMessageLength {

--- a/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskDescriptionEditor.vue
+++ b/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskDescriptionEditor.vue
@@ -40,7 +40,7 @@
     <div
       v-if="displayEditor && editorReady"
       :class="charsCount > MESSAGE_MAX_LENGTH ? 'tooManyChars' : ''"
-      class="activityCharsCount flex d-flex justify-end"
+      class="activityCharsCount"
       style="">
       {{ charsCount }}/{{ MESSAGE_MAX_LENGTH }}
       <i class="uiIconMessageLength"></i>
@@ -53,7 +53,7 @@
       :disabled="saveDescriptionButtonDisabled"
       depressed
       outlined
-      class="btn mt-1 ml-auto d-flex px-2 btn-primary v-btn v-btn--contained theme--light v-size--default"
+      class="btn mt-2 ml-auto d-flex px-2 btn-primary v-btn v-btn--contained theme--light v-size--default"
       @click="saveDescription">
       {{ $t('label.apply') }}
     </v-btn>


### PR DESCRIPTION
Prior to this change, the buttons of CKEditor on Task Description aren't clickable. The problem is caused by the relative div element that displays number of characters which hides the buttons. This fix will change the style of this block to reduce its width.