### PR TITLE
TASK-58036 Replaced "no data" label with "no result" and added new la…

### DIFF
--- a/task-management/src/main/resources/locale/portlet/taskManagement_en.properties
+++ b/task-management/src/main/resources/locale/portlet/taskManagement_en.properties
@@ -114,6 +114,7 @@ label.inviteManagers=Invite Managers
 label.inviteParticipant=@mention someone
 label.searchPlaceholder=Start typing to search
 label.noDataLabel=No data
+label.noResultLabel=No result
 label.noSpace=No Space
 label.watch=Watch
 label.unwatch=Unwatch

--- a/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskAssignment.vue
+++ b/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskAssignment.vue
@@ -131,7 +131,7 @@ export default {
     suggesterLabels() {
       return {
         placeholder: this.$t('label.assignee'),
-        noDataLabel: this.$t('label.noDataLabel'),
+        noDataLabel: this.$t('label.noResultLabel'),
       };
     },
     searchOptions() {


### PR DESCRIPTION
prior this changes, when starting to search user to assign it and no suggesting user was found.`no data` label  is displayed which has no meaning.So this label replaced with new label `no result`