### PR TITLE
Task-58401: due date of task card decremented n-1 day with timezone negative (#101)

### DIFF
--- a/task-management/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TaskViewCard.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TaskViewCard.vue
@@ -139,7 +139,7 @@ export default {
   computed: {
     taskDueDate() { 
       if (this.task?.task?.dueDate?.time) {
-        const formattedDate = `${this.task.task.dueDate.year + 1900}-${this.task.task.dueDate.month + 1}-${this.task.task.dueDate.date}`;
+        const formattedDate = `${this.task.task.dueDate.year + 1900}/${this.task.task.dueDate.month + 1}/${this.task.task.dueDate.date}`;
         return new Date(formattedDate);
       }
       return null;


### PR DESCRIPTION
Problem: when go to task bord then due date of task is decremented n-1 day in Firefox with timezone negative GMT-6
Fix: format of date yyyy/mm/dd is recognized by all browsers