### PR TITLE
Task-52446: Fix task color when priority is none

### DIFF
--- a/task-management/src/main/webapp/skin/css/tasks.less
+++ b/task-management/src/main/webapp/skin/css/tasks.less
@@ -1519,7 +1519,7 @@
       //border-right: 5px solid @successColor ~'!important; /** orientation=rt */ ';
     }
     .taskNonePriority {
-      border-left: 5px solid @primaryColor ~'!important; /** orientation=lt */ ';
+      border-left: 5px solid #476A9C ~'!important; /** orientation=lt */ ';
       //border-right: 5px solid @primaryColor ~'!important; /** orientation=rt */ ';
     }
     .taskComment {


### PR DESCRIPTION
ISSUE : When user change a primary color to any color except blue , the task color if the priority is none check the primary color of the board .( conflict @primarycolor set the primary color of the board )
FIX : fix the color of task when the priority is none to blue
(cherry picked from commit 46613ec483822c21f527210cf7b3d6ed40494635)