### PR TITLE
Allow to display Task Drawer in full window width

### DIFF
--- a/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawer.vue
+++ b/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawer.vue
@@ -30,6 +30,7 @@
       class="taskDrawer"
       body-classes="hide-scroll decrease-z-index-more"
       right
+      allow-expand
       @closed="onCloseDrawer">
       <template 
         v-if="task.id" 


### PR DESCRIPTION
By introducing `allow-expand` parameter in `exo-drawer`, a new button will be added to allow user to read big tasks in full screen width.