### PR TITLE
TASK-59254: Tasks comments aren't displayed in  tasks widget of snapshot page.

### DIFF
--- a/task-management/src/main/webapp/vue-app/taskDrawer/initComponents.js
+++ b/task-management/src/main/webapp/vue-app/taskDrawer/initComponents.js
@@ -23,6 +23,7 @@ import TaskPriority from './components/TaskDrawerComponents/TaskPriority.vue';
 import TaskStatus from './components/TaskDrawerComponents/TasksStatus.vue';
 import TaskFormDatePickers from './components/TaskDrawerComponents/TaskFormDatePickers.vue';
 import TaskChangesDrawer from './components/TaskDrawerComponents/TaskChangesDrawer.vue';
+import '../taskCommentsDrawer/initComponents';
 
 const components = {
   'task-drawer': TaskDrawer,


### PR DESCRIPTION
Prior to this change, when open the task drawer from the snapshot page, comments aren't displayed.
To fix this, call the `initComponents` of the `taskCommentsDrawer` in the `initComponents` of the `taskDrawer`.