### PR TITLE
TASK-59256: Tasks comments aren't displayed in tasks widget of snapshot page.

### DIFF
--- a/task-management/src/main/webapp/vue-app/tasks/components/TasksApp.vue
+++ b/task-management/src/main/webapp/vue-app/tasks/components/TasksApp.vue
@@ -169,6 +169,7 @@
 
 <script>
 import {filterTasksList} from '../../../js/tasksService';
+import '../../taskCommentsDrawer/initComponents';
 
 export default {
 


### PR DESCRIPTION
Prior to this change, when opening the task drawer from the snapshot page, comments were not showing because the task comment component did not load in the DOM .
To fix this, initialize the task comment component in `taskApp`