### PR TITLE
fix: Fix assignment of multiple task coworkers - TASK-59718 - Meeds-io/meeds-306 #124

### DIFF
--- a/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawer.vue
+++ b/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawer.vue
@@ -593,7 +593,7 @@ export default {
       }
     },
     updateTaskCoworker(value) {
-      if (this.task.id !== null && this.oldTask.coworker!==value) {
+      if (this.task.id !== null) {
         if (value && value.length) {
           this.task.coworker = value;
         } else {

--- a/task-management/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TaskViewCard.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TaskViewCard.vue
@@ -148,7 +148,9 @@ export default {
       const usersList = [];
       if (this.assigneeAndCoworkerArray && this.assigneeAndCoworkerArray.length ) {
         this.assigneeAndCoworkerArray.forEach(user => {
-          usersList.push({'userName': user.username});
+          if (!usersList.includes({'userName': user.username})) {
+            usersList.push({'userName': user.username});
+          }
         });
       }
       return usersList;
@@ -234,10 +236,11 @@ export default {
       }
     },
     updateTaskCoworker(value,id){
+      const coworkers = value.coworker;
       if (this.task.id === id){
-        if (value && value.length) {
+        if (coworkers && coworkers.length) {
           this.task.coworker=[];
-          value.forEach((coworker) => {
+          coworkers.forEach((coworker) => {
             this.$identityService.getIdentityByProviderIdAndRemoteId('organization',coworker).then(user => {
               const taskCoworker = {
                 id: `organization:${user.remoteId}`,


### PR DESCRIPTION
Prior to this change, when we want to assign 3 or all members as coworkers, only 1 collaborator is assigned.
After this change, all coworkers will be assigned correctly.