### PR TITLE
 fix: Fix task due and start dates issue - TASK-60074- Meeds-io/meeds#327

### DIFF
--- a/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawer.vue
+++ b/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawer.vue
@@ -463,6 +463,9 @@ export default {
       }
     },
     updateTaskStartDate(value) {
+      if (value !== 'none' && value.date === 1 && value.month === 0 && value.timezoneOffset < 0) {
+        value.year += 1;
+      }
       if (value && value !== 'none'  && (!this.oldTask.startDate|| !this.datesEquals(this.oldTask.startDate,value))) {
         if (this.task.id != null) {
           this.task.startDate = value;
@@ -502,6 +505,9 @@ export default {
       }
     },
     updateTaskDueDate(value) {
+      if (value !== 'none' && value.date === 1 && value.month === 0 && value.timezoneOffset < 0) {
+        value.year += 1;
+      }
       if (value && value !== 'none' && (!this.oldTask.dueDate || !this.datesEquals(this.oldTask.dueDate,value))) {
         if (this.task.id !== null) {
           this.task.dueDate = value;


### PR DESCRIPTION
Prior to this change, when we set the start and due date of a task by the first day of the year, the date is delayed by one year. After this change, the due and start date should be set correctly. 