### PR TITLE
fix: Fix App Center Override Mode Settings - MEED-768

### DIFF
--- a/task-management/src/main/webapp/WEB-INF/conf/task-addon/app-center-configuration.xml
+++ b/task-management/src/main/webapp/WEB-INF/conf/task-addon/app-center-configuration.xml
@@ -32,7 +32,7 @@
           <value>${exo.app-center.tasks.override:false}</value>
         </value-param>
         <value-param>
-          <name>override</name>
+          <name>override-mode</name>
           <value>${exo.app-center.tasks.override-mode:merge}</value>
         </value-param>
         <object-param>


### PR DESCRIPTION
Prior to this change, the parameter with name 'override' was duplicated in App Center Settings of Tasks so that we cannot overwrite configuration using system Properties. This fix will make sure to rename the property with its intended correct name 'override-mode' that will be configurable using system property 'exo.app-center.tasks.override-mode'.

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
