### PR TITLE
fix: Fix vertical and horizontal scroll bars to tasks display in Planview - EXO-59238 - Meeds-io/meeds#350

### DIFF
--- a/task-management/src/main/webapp/skin/css/tasks.less
+++ b/task-management/src/main/webapp/skin/css/tasks.less
@@ -3767,6 +3767,8 @@
     height: calc(~"100vh - 250px")!important;
     overflow: hidden;
     position: relative;
+    overflow-x: scroll;
+    overflow-y: scroll;
     &::-webkit-scrollbar {
       height: 6px;
       width: 6px;


### PR DESCRIPTION
Prior to this change, in tasks application, when switching to the PLAN view, only the top 10 tasks are displayed vertically and some tasks are displayed horizontally depending on when they are scheduled. After this change, we will display vertical and horizontal scroll bars allowing the user to scroll horizontally and vertically in order to see all tasks.

(cherry picked from commit  [563d938](https://github.com/Meeds-io/task/commit/563d93800768126cc57be4a6998257238b416d91))