### PR TITLE
fix: Fix typed label filter isn't maintained -EXO-60110 - Meeds-io/meeds#360

### DIFF
--- a/task-management/src/main/webapp/vue-app/tasks-management/components/tasks/TasksLabelsDrawer.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/tasks/TasksLabelsDrawer.vue
@@ -133,7 +133,6 @@ export default {
     document.addEventListener('loadTaskLabels', event => {
       if (event && event.detail) {
         const task = event.detail;
-        this.model = [];
         if (task.id!=null) {
           this.getTaskLabels();
           this.$taskDrawerApi.getTaskLabels(task.id).then((labels) => {
@@ -152,9 +151,7 @@ export default {
         this.getProjectLabels(this.projectId);
       }
     });
-    this.$root.$on('reset-filter-task-group-sort',() =>{
-      this.model = null;
-    });
+    
   },
   methods: {
     filter(item, queryText, itemText) {


### PR DESCRIPTION
Prior to this change, when we filter tasks by typed label, the previously typed label is not maintained. After this change, the previously typed label is maintained by stopping the filter reset that set the model value to null.