### PR TITLE
fix: Fix typed label filter isn't maintained -EXO-60110 - Meeds-io/meeds#360

### DIFF
--- a/task-management/src/main/webapp/vue-app/tasks-management/components/tasks/TasksFilterDrawer.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/tasks/TasksFilterDrawer.vue
@@ -305,7 +305,6 @@ export default {
       this.orderBy = projectId > 0 && localStorageSaveFilter && localStorageSaveFilter.projectId === projectId && localStorageSaveFilter.orderBy ||
       localStorageSaveFilter && localStorageSaveFilter.projectId === 'None' && localStorageSaveFilter.orderBy ? localStorageSaveFilter.orderBy : '';
       
-      this.$root.$emit('reset-filter-task-group-sort', this.groupBy);
       this.$root.$emit('reset-filter-task-sort', this.orderBy);
       this.$refs.filterTasksDrawer.open();
     },

--- a/task-management/src/main/webapp/vue-app/tasks-management/components/tasks/TasksLabelsDrawer.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/tasks/TasksLabelsDrawer.vue
@@ -152,7 +152,9 @@ export default {
         this.getProjectLabels(this.projectId);
       }
     });
-    
+    this.$root.$on('reset-filter-task-group-sort',() =>{
+      this.model = null;
+    });
   },
   methods: {
     filter(item, queryText, itemText) {

--- a/task-management/src/main/webapp/vue-app/tasks-management/components/tasks/TasksLabelsDrawer.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/tasks/TasksLabelsDrawer.vue
@@ -133,6 +133,7 @@ export default {
     document.addEventListener('loadTaskLabels', event => {
       if (event && event.detail) {
         const task = event.detail;
+        this.model = [];
         if (task.id!=null) {
           this.getTaskLabels();
           this.$taskDrawerApi.getTaskLabels(task.id).then((labels) => {

--- a/task-management/src/main/webapp/vue-app/tasks-management/components/tasks/TasksLabelsDrawer.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/tasks/TasksLabelsDrawer.vue
@@ -133,7 +133,6 @@ export default {
     document.addEventListener('loadTaskLabels', event => {
       if (event && event.detail) {
         const task = event.detail;
-        this.model = [];
         if (task.id!=null) {
           this.getTaskLabels();
           this.$taskDrawerApi.getTaskLabels(task.id).then((labels) => {
@@ -152,9 +151,7 @@ export default {
         this.getProjectLabels(this.projectId);
       }
     });
-    this.$root.$on('reset-filter-task-group-sort',() =>{
-      this.model = null;
-    });
+    
   },
   methods: {
     filter(item, queryText, itemText) {


### PR DESCRIPTION
Prior to this change, when we filter tasks by typed label, the previously typed label is not maintained when reopening the filter drawer. After this change, the previously typed label is maintained by removing the filter reset that set the model value to null when reopening the filter drawer.