### PR TITLE
fix: Fix typed label filter isn't maintained -EXO-60110 - Meeds-io/meeds#360

### DIFF
--- a/task-management/src/main/webapp/vue-app/tasks-management/components/tasks/TasksFilterDrawer.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/tasks/TasksFilterDrawer.vue
@@ -305,7 +305,6 @@ export default {
       this.orderBy = projectId > 0 && localStorageSaveFilter && localStorageSaveFilter.projectId === projectId && localStorageSaveFilter.orderBy ||
       localStorageSaveFilter && localStorageSaveFilter.projectId === 'None' && localStorageSaveFilter.orderBy ? localStorageSaveFilter.orderBy : '';
       
-      this.$root.$emit('reset-filter-task-group-sort', this.groupBy);
       this.$root.$emit('reset-filter-task-sort', this.orderBy);
       this.$refs.filterTasksDrawer.open();
     },


### PR DESCRIPTION
Prior to this change, when we filter tasks by typed label, the previously typed label is not maintained when reopening the filter drawer. After this change, the previously typed label is maintained by removing the filter reset that set the model value to null when reopening the filter drawer.

(cherry picked from commit https://github.com/Meeds-io/task/commit/729c4895cd6799f3d5ecbc6f2eb94d4a87aa1527)