### PR TITLE
fix: task drawer does not open for task search results - EXO-62888 - Meeds-io/meeds#892

### DIFF
--- a/task-management/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/task-management/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -19,24 +19,17 @@
 	xsi:schemaLocation="http://www.exoplatform.org/xml/ns/gatein_resources_1_4 http://www.exoplatform.org/xml/ns/gatein_resources_1_4"
 	xmlns="http://www.exoplatform.org/xml/ns/gatein_resources_1_4">
 
-  <portlet-skin>
-    <application-name>task-management</application-name>
-    <portlet-name>TasksManagement</portlet-name>
-    <skin-name>Enterprise</skin-name>
-    <css-path>/skin/css/tasks.css</css-path>
-  </portlet-skin>
-
-  <portlet-skin>
-    <application-name>task-management</application-name>
-    <portlet-name>tasks</portlet-name>
-    <skin-name>Enterprise</skin-name>
-    <css-path>/skin/css/tasks.css</css-path>
-  </portlet-skin>
-
   <portal-skin>
     <skin-name>Enterprise</skin-name>
     <skin-module>taskCommentsDrawer</skin-module>
     <css-path>/skin/css/tasksCommentDrawer.css</css-path>
+    <css-priority>2</css-priority>
+  </portal-skin>
+
+  <portal-skin>
+    <skin-name>Enterprise</skin-name>
+    <skin-module>taskCommentsDrawer</skin-module>
+    <css-path>/skin/css/tasks.css</css-path>
     <css-priority>2</css-priority>
   </portal-skin>
 

--- a/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawer.vue
+++ b/task-management/src/main/webapp/vue-app/taskDrawer/components/TaskDrawer.vue
@@ -32,7 +32,7 @@
       right
       @closed="onCloseDrawer">
       <template 
-        v-if="task.id" 
+        v-if="task && task.id"
         slot="title">
         <div class="drawerTitleAndProject d-flex">
           <i
@@ -88,13 +88,13 @@
               icon
               dark
               @click="updateCompleted">
-              <v-icon v-if="task.completed" class="markAsCompletedBtn">mdi-checkbox-marked-circle</v-icon>
+              <v-icon v-if="task && task.completed" class="markAsCompletedBtn">mdi-checkbox-marked-circle</v-icon>
               <v-icon v-else class="markAsCompletedBtn">mdi-checkbox-blank-circle-outline</v-icon>
             </v-btn>
             <v-textarea
               ref="autoFocusInput4"
               v-model="taskTitle"
-              :class="{taskCompleted: task.completed}"
+              :class="{taskCompleted: task && task.completed}"
               :placeholder="$t('label.tapTask.name')"
               :autofocus="!task || !task.id"
               type="text"
@@ -106,7 +106,7 @@
               @change="updateTaskTitle" />
           </div>
           <div
-            v-if="task && task && task.id"
+            v-if="task && task.id"
             :title="$t('tooltip.viewAllChanges')"
             class="lastUpdatedTask pb-3"
             @click="$root.$emit('displayTaskChanges')">
@@ -152,13 +152,13 @@
           </div>
           <div class="taskLabelsName mt-3 mb-3">
             <task-labels
-              v-if="task.status && task.status.project"
+              v-if="task && task.status && task.status.project"
               :task="task"
               @labelsListOpened="closePriority(); closeStatus(); closeProjectsList();closeTaskDates();closeAssignements()" />
           </div>
           <extension-registry-components
             :params="{
-              taskId: task.id,
+              taskId: task && task.id,
               spaceId: taskSpaceId,
             }"
             name="TaskDrawer"
@@ -168,7 +168,7 @@
             class="d-flex" />
           <v-divider class="my-0" />
           <v-flex
-            v-if="task.id"
+            v-if="task && task.id"
             xs12
             class="pt-2 taskCommentsAndChanges">
             <task-view-all-comments
@@ -177,7 +177,7 @@
           </v-flex>
         </div>
       </template>
-      <template v-if="!task.id" slot="footer">
+      <template v-if="task && !task.id" slot="footer">
         <div class="d-flex">
           <v-spacer />
           <v-btn

--- a/task-management/src/main/webapp/vue-app/taskSearch/main.js
+++ b/task-management/src/main/webapp/vue-app/taskSearch/main.js
@@ -15,7 +15,7 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 import './initComponents.js';
-import '../taskDrawer/initComponents.js';
+import '../taskDrawer/main.js';
 
 Vue.use(Vuetify);
 


### PR DESCRIPTION
Priori to this fix, when clicking on the task search results, the drawer does not open and it is not possible to interact with it. The fix adds needed services and provide additional nullity checks to fix all errors. besides, it transfors the CSS file of task as a global skin file to be used whenever the task drawer is opened.
