### PR TITLE
feat: Use Extended CKEditor configuration - MEED-2058 - Meeds-io/MIPs#59

### DIFF
--- a/webapps/src/main/webapp/vue-app/taskCommentsDrawer/components/TaskCommentEditor.vue
+++ b/webapps/src/main/webapp/vue-app/taskCommentsDrawer/components/TaskCommentEditor.vue
@@ -187,7 +187,7 @@ export default {
       CKEDITOR.basePath = '/commons-extension/ckeditor/';
       const self = this;
       $(this.$refs[`editor-${this.id}`]).ckeditor({
-        customConfig: '/commons-extension/ckeditorCustom/config.js',
+        customConfig: `${eXo.env.portal.context}/${eXo.env.portal.rest}/richeditor/configuration?type=task-comment&v=${eXo.env.client.assetsVersion}`,
         extraPlugins: extraPlugins,
         removePlugins: 'confirmBeforeReload,maximize,resize',
         toolbar,

--- a/webapps/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskDescriptionEditor.vue
+++ b/webapps/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskDescriptionEditor.vue
@@ -193,7 +193,7 @@ export default {
       CKEDITOR.basePath = '/commons-extension/ckeditor/';
       const self = this;
       $(this.$refs.editor).ckeditor({
-        customConfig: '/commons-extension/ckeditorCustom/config.js',
+        customConfig: `${eXo.env.portal.context}/${eXo.env.portal.rest}/richeditor/configuration?type=task-description&v=${eXo.env.client.assetsVersion}`,
         extraPlugins: extraPlugins,
         removePlugins: 'confirmBeforeReload,maximize,resize',
         toolbar,

--- a/webapps/src/main/webapp/vue-app/tasks-management/components/Project/ExoTaskEditor.vue
+++ b/webapps/src/main/webapp/vue-app/tasks-management/components/Project/ExoTaskEditor.vue
@@ -130,7 +130,7 @@ export default {
       CKEDITOR.basePath = '/commons-extension/ckeditor/';
       const self = this;
       $(this.$refs.editor).ckeditor({
-        customConfig: '/commons-extension/ckeditorCustom/config.js',
+        customConfig: `${eXo.env.portal.context}/${eXo.env.portal.rest}/richeditor/configuration?type=project-description&v=${eXo.env.client.assetsVersion}`,
         extraPlugins: extraPlugins,
         allowedContent: true,
         removePlugins: 'image,confirmBeforeReload,maximize,resize',


### PR DESCRIPTION
Prior to this change, the CKEditor configuration was retrieved from a static JS file. This change will use the dynamically generated CKEditor configuration REST endpoint.