### PR TITLE
feat: Enable Push notifications Channel when addon installed - MEED-2062 - Meeds-io/meeds#900

### DIFF
--- a/webapps/src/main/webapp/WEB-INF/conf/task-addon/notification/task-notification-plugin.xml
+++ b/webapps/src/main/webapp/WEB-INF/conf/task-addon/notification/task-notification-plugin.xml
@@ -366,7 +366,7 @@
         </value-param>
       </init-params>
     </component-plugin>
-    <component-plugin>
+    <component-plugin profiles="push-notifications">
       <name>web.channel.task.template</name>
       <set-method>registerTemplateProvider</set-method>
       <type>org.exoplatform.task.integration.notification.PushTemplateProvider</type>


### PR DESCRIPTION
Prior to this change, Push notification channel was configured even when the addon isn't installed. This change will add this configuration only when push-notifications addon is added.