### PR TITLE
fix: Process space is displayed twice in the process task project participants - EXO-62456 -  Meeds-io/meeds#924

### DIFF
--- a/services/src/main/java/org/exoplatform/task/rest/ProjectRestService.java
+++ b/services/src/main/java/org/exoplatform/task/rest/ProjectRestService.java
@@ -474,7 +474,8 @@ public class ProjectRestService implements ResourceContainer {
     projectJson.put("name", project.getName());
     projectJson.put("color", project.getColor());
     projectJson.put("participator", projectParticipators);
-    projectJson.put("participatorsDetail", participatorsDetail);
+    //remove the redundancy from the participatorsDetails
+    projectJson.put("participatorsDetail", participatorsDetail.toList().stream().distinct().toArray());
     projectJson.put("hiddenOn", project.getHiddenOn());
     projectJson.put("manager", projectService.getManager(projectId));
     projectJson.put("managersDetail", managersDetail);


### PR DESCRIPTION
Before this change, the process space was displayed twice in the process task project participants. The problem occurred when we built the participants' Details list from the project permission list, resulting in the participants' Details project list having redundant participators.

For example, if we had the permissions `manager:space/test` and `member:space/test`, the participants' Details list was built with redundant participator `space test`. This change is going to remove the redundancy from the participators' Details.