### PR TITLE
Fix: filter glitches on myTasks tab when making an edit on a task from the filtered list - EXO-64197

### DIFF
--- a/task-management/src/main/webapp/vue-app/tasks-management/components/tasks/TasksDashboard.vue
+++ b/task-management/src/main/webapp/vue-app/tasks-management/components/tasks/TasksDashboard.vue
@@ -490,8 +490,7 @@ export default {
       });
     },
     updateTasksList() {
-      const filterTasks = this.filterActive ? this.taskQueryFilter : this.filterTasks;
-      this.$tasksService.filterTasksList(filterTasks, this.groupBy, this.orderBy, this.labels).then(data => {
+      this.$tasksService.filterTasksList(this.filterTasks, this.groupBy, this.orderBy, this.labels).then(data => {
 
         if (this.filterActive) {
           this.filterTaskQueryResult = data;


### PR DESCRIPTION
prior to this change, when user select any option from primary filter and select any item from 'group by' except the default one (none) besides making edits on a task from the list, the filter glitches because of a wrong parameter passed to 'filterTasksList()'.

after this change the tasks would be filtered correctly