### PR TITLE
fix: Change task drawer title - EXO - 65012

### DIFF
--- a/webapps/src/main/webapp/vue-app/taskDrawer/components/TaskDrawer.vue
+++ b/webapps/src/main/webapp/vue-app/taskDrawer/components/TaskDrawer.vue
@@ -39,7 +39,7 @@
             v-if="addBackArrow"
             class="uiIcon uiArrowBAckIcon"
             @click="closeTaskDrawer"></i>
-          <span>{{ $t('label.drawer.header') }}</span>
+          <span>{{ $t('label.project') }}</span>
           <div class="taskProjectName">
             <task-projects
               :task="task"


### PR DESCRIPTION
Opening the task drawer displays the label edit task next to project name, however, it would be more adequate to display the label Project instead.

(cherry picked from commit c60ad4faca601153eb9b85420dd12c3da697b285)
