### PR TITLE
feat: Add dedicated event for task archiving - MEED-2201 - Meeds-io/MIPs#50

### DIFF
--- a/services/src/main/java/org/exoplatform/task/integration/gamification/GamificationTaskCommentListener.java
+++ b/services/src/main/java/org/exoplatform/task/integration/gamification/GamificationTaskCommentListener.java
@@ -1,9 +1,9 @@
 package org.exoplatform.task.integration.gamification;
 
+import static io.meeds.gamification.constant.GamificationConstant.EVENT_NAME;
 import static io.meeds.gamification.constant.GamificationConstant.OBJECT_ID_PARAM;
 import static io.meeds.gamification.constant.GamificationConstant.OBJECT_TYPE_PARAM;
 import static io.meeds.gamification.constant.GamificationConstant.RECEIVER_ID;
-import static io.meeds.gamification.constant.GamificationConstant.EVENT_NAME;
 import static io.meeds.gamification.constant.GamificationConstant.SENDER_ID;
 import static io.meeds.gamification.listener.GamificationGenericListener.GENERIC_EVENT_NAME;
 import static org.exoplatform.task.util.TaskUtil.TASK_OBJECT_TYPE;
@@ -11,7 +11,6 @@ import static org.exoplatform.task.util.TaskUtil.TASK_OBJECT_TYPE;
 import java.util.HashMap;
 import java.util.Map;
 
-import io.meeds.gamification.service.RuleService;
 import org.exoplatform.services.listener.Event;
 import org.exoplatform.services.listener.Listener;
 import org.exoplatform.services.listener.ListenerService;
@@ -25,16 +24,12 @@ public class GamificationTaskCommentListener extends Listener<TaskService, Comme
 
   private static final String GAMIFICATION_TASK_ADDON_COMMENT_TASK = "commentTask";
 
-  protected RuleService       ruleService;
-
   protected IdentityManager   identityManager;
 
   protected ListenerService   listenerService;
 
-  public GamificationTaskCommentListener(RuleService ruleService,
-                                         IdentityManager identityManager,
+  public GamificationTaskCommentListener(IdentityManager identityManager,
                                          ListenerService listenerService) {
-    this.ruleService = ruleService;
     this.identityManager = identityManager;
     this.listenerService = listenerService;
   }

--- a/services/src/main/java/org/exoplatform/task/util/StorageUtil.java
+++ b/services/src/main/java/org/exoplatform/task/util/StorageUtil.java
@@ -56,7 +56,8 @@ public final class StorageUtil{
         changeLogEntry.setAuthorFullName(userService.loadUser(changeLog.getAuthor()).getDisplayName());
         changeLogEntry.setAuthorAvatarUrl(userService.loadUser(changeLog.getAuthor()).getAvatar());
         changeLogEntry.setExternal(userService.loadUser(changeLog.getAuthor()).isExternal());
-        if(changeLog.getActionName().equals("assign")||changeLog.getActionName().equals("unassign")){
+        if (changeLog.getActionName().equals("assign") || changeLog.getActionName().equals("unassign")
+            || changeLog.getActionName().equals("assignCoworker") || changeLog.getActionName().equals("unassignCoworker")) {
             changeLogEntry.setTargetFullName(userService.loadUser(changeLog.getTarget()).getDisplayName());
             changeLogEntry.setIsTargetFullNameExternal(CommentUtil.isExternal(userService.loadUser(changeLog.getTarget()).getUsername()));
         }

--- a/services/src/test/java/org/exoplatform/task/integration/gamification/GamificationTaskUpdateListenerTest.java
+++ b/services/src/test/java/org/exoplatform/task/integration/gamification/GamificationTaskUpdateListenerTest.java
@@ -1,0 +1,201 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2020 - 2023 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+package org.exoplatform.task.integration.gamification;
+
+import static io.meeds.gamification.constant.GamificationConstant.EVENT_NAME;
+import static io.meeds.gamification.constant.GamificationConstant.SENDER_ID;
+import static io.meeds.gamification.listener.GamificationGenericListener.GENERIC_EVENT_NAME;
+import static org.exoplatform.task.integration.gamification.GamificationTaskUpdateListener.GAMIFICATION_TASK_ADDON_COMPLETED_TASK;
+import static org.exoplatform.task.integration.gamification.GamificationTaskUpdateListener.GAMIFICATION_TASK_ADDON_COMPLETED_TASK_ASSIGNED;
+import static org.exoplatform.task.integration.gamification.GamificationTaskUpdateListener.GAMIFICATION_TASK_ADDON_COMPLETED_TASK_COWORKER;
+import static org.exoplatform.task.integration.gamification.GamificationTaskUpdateListener.GAMIFICATION_TASK_ADDON_CREATE_TASK;
+import static org.exoplatform.task.integration.gamification.GamificationTaskUpdateListener.GAMIFICATION_TASK_ADDON_UPDATE_TASK;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Objects;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import org.exoplatform.services.listener.Event;
+import org.exoplatform.services.listener.ListenerService;
+import org.exoplatform.services.security.ConversationState;
+import org.exoplatform.social.core.identity.model.Identity;
+import org.exoplatform.social.core.manager.IdentityManager;
+import org.exoplatform.task.dto.ChangeLogEntry;
+import org.exoplatform.task.dto.TaskDto;
+import org.exoplatform.task.service.TaskPayload;
+import org.exoplatform.task.service.TaskService;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GamificationTaskUpdateListenerTest {
+
+  private static final long   TASK_ID   = 2l;
+
+  private static final String USERNAME  = "test";
+
+  private static final String COWORKER1 = "cotest1";
+
+  private static final String COWORKER2 = "cotest2";
+
+  private static final String COWORKER3 = "cotest3";
+
+  @Mock
+  private TaskService         taskService;
+
+  @Mock
+  private IdentityManager     identityManager;
+
+  @Mock
+  private ListenerService     listenerService;
+
+  @Mock
+  private TaskDto             oldTask;
+
+  @Mock
+  private TaskDto             task;
+
+  @Before
+  public void setUp() {
+    when(task.getId()).thenReturn(TASK_ID);
+    ConversationState.setCurrent(new ConversationState(new org.exoplatform.services.security.Identity(USERNAME)));
+  }
+
+  @After
+  public void tearDown() {
+    ConversationState.setCurrent(null);
+  }
+
+  @Test
+  public void testCreateTask() throws Exception {
+    GamificationTaskUpdateListener gamificationTaskUpdateListener = new GamificationTaskUpdateListener(taskService,
+                                                                                                       identityManager,
+                                                                                                       listenerService);
+    Identity userIdentity = mock(Identity.class);
+    when(userIdentity.getId()).thenReturn("1");
+    when(identityManager.getOrCreateUserIdentity(USERNAME)).thenReturn(userIdentity);
+    Event<TaskService, TaskPayload> event = new Event<TaskService, TaskPayload>(null, null, new TaskPayload(null, task));
+    gamificationTaskUpdateListener.onEvent(event);
+
+    verify(listenerService,
+           times(1)).broadcast(eq(GENERIC_EVENT_NAME),
+                               argThat((Map<String, String> source) -> source.get(EVENT_NAME)
+                                                                             .equals(GAMIFICATION_TASK_ADDON_CREATE_TASK)),
+                               argThat(Objects::isNull));
+
+  }
+
+  @Test
+  public void testUpdateTask() throws Exception {
+    mockIdentity("1", USERNAME);
+    mockIdentity("2", COWORKER1);
+    mockIdentity("3", COWORKER2);
+    mockIdentity("4", COWORKER3);
+
+    when(taskService.getTaskLogs(eq(TASK_ID), anyInt(), anyInt())).thenReturn(Arrays.asList(newChangeLogEntry("assign", USERNAME),
+                                                                                            newChangeLogEntry("assignCoworker",
+                                                                                                              COWORKER1),
+                                                                                            newChangeLogEntry("assignCoworker",
+                                                                                                              COWORKER2),
+                                                                                            newChangeLogEntry("assignCoworker",
+                                                                                                              COWORKER3)));
+
+    new GamificationTaskUpdateListener(taskService,
+                                       identityManager,
+                                       listenerService).onEvent(new Event<TaskService, TaskPayload>(null, null, new TaskPayload(oldTask, task)));
+
+    verify(listenerService,
+           times(1)).broadcast(eq(GENERIC_EVENT_NAME),
+                               argThat((Map<String, String> source) -> source.get(EVENT_NAME)
+                                                                             .equals(GAMIFICATION_TASK_ADDON_UPDATE_TASK)),
+                               eq(null));
+    verify(listenerService,
+           never()).broadcast(eq(GENERIC_EVENT_NAME),
+                              argThat((Map<String, String> source) -> source.get(EVENT_NAME)
+                                                                            .equals(GAMIFICATION_TASK_ADDON_COMPLETED_TASK)),
+                              eq(null));
+
+    when(task.isCompleted()).thenReturn(true);
+    new GamificationTaskUpdateListener(taskService,
+                                       identityManager,
+                                       listenerService).onEvent(new Event<TaskService, TaskPayload>(null, null, new TaskPayload(oldTask, task)));
+
+    verify(listenerService,
+           times(1)).broadcast(eq(GENERIC_EVENT_NAME),
+                               argThat((Map<String, String> source) -> source.get(EVENT_NAME)
+                                                                             .equals(GAMIFICATION_TASK_ADDON_UPDATE_TASK)),
+                               eq(null));
+
+    verify(listenerService,
+           times(1)).broadcast(eq(GENERIC_EVENT_NAME),
+                               argThat((Map<String, String> source) -> source.get(EVENT_NAME)
+                                                                             .equals(GAMIFICATION_TASK_ADDON_COMPLETED_TASK_ASSIGNED)),
+                               eq(null));
+    verify(listenerService,
+           times(3)).broadcast(eq(GENERIC_EVENT_NAME),
+                               argThat((Map<String, String> source) -> source.get(EVENT_NAME)
+                                                                             .equals(GAMIFICATION_TASK_ADDON_COMPLETED_TASK_COWORKER)),
+                               eq(null));
+    verify(listenerService,
+           times(1)).broadcast(eq(GENERIC_EVENT_NAME),
+                               argThat((Map<String, String> source) -> source.get(EVENT_NAME)
+                                                                             .equals(GAMIFICATION_TASK_ADDON_COMPLETED_TASK_COWORKER)
+                                   && source.get(SENDER_ID).equals("2")),
+                               eq(null));
+    verify(listenerService,
+           times(1)).broadcast(eq(GENERIC_EVENT_NAME),
+                               argThat((Map<String, String> source) -> source.get(EVENT_NAME)
+                                                                             .equals(GAMIFICATION_TASK_ADDON_COMPLETED_TASK_COWORKER)
+                                   && source.get(SENDER_ID).equals("3")),
+                               eq(null));
+    verify(listenerService,
+           times(1)).broadcast(eq(GENERIC_EVENT_NAME),
+                               argThat((Map<String, String> source) -> source.get(EVENT_NAME)
+                                                                             .equals(GAMIFICATION_TASK_ADDON_COMPLETED_TASK_COWORKER)
+                                   && source.get(SENDER_ID).equals("4")),
+                               eq(null));
+  }
+
+  private ChangeLogEntry newChangeLogEntry(String logName, String target) {
+    ChangeLogEntry changeLogEntry = new ChangeLogEntry();
+    changeLogEntry.setTarget(target);
+    changeLogEntry.setActionName(logName);
+    return changeLogEntry;
+  }
+
+  private void mockIdentity(String identityId, String username) {
+    Identity userIdentity = mock(Identity.class);
+    when(userIdentity.getId()).thenReturn(identityId);
+    when(userIdentity.isEnable()).thenReturn(true);
+    when(identityManager.getOrCreateUserIdentity(username)).thenReturn(userIdentity);
+  }
+
+}

--- a/webapps/src/main/webapp/WEB-INF/conf/task-addon/gamification-integration-configuration.xml
+++ b/webapps/src/main/webapp/WEB-INF/conf/task-addon/gamification-integration-configuration.xml
@@ -65,6 +65,17 @@
       </init-params>
     </component-plugin>
     <component-plugin>
+      <name>rule.CompleteTask</name>
+      <set-method>addPlugin</set-method>
+      <type>io.meeds.gamification.plugin.RuleConfigPlugin</type>
+      <init-params>
+        <value-param>
+          <name>rule-event</name>
+          <value>completeTask</value>
+        </value-param>
+      </init-params>
+    </component-plugin>
+    <component-plugin>
       <name>rule.CompleteTaskAssigned</name>
       <set-method>addPlugin</set-method>
       <type>io.meeds.gamification.plugin.RuleConfigPlugin</type>

--- a/webapps/src/main/webapp/vue-app/engagementCenterExtensions/extensions.js
+++ b/webapps/src/main/webapp/vue-app/engagementCenterExtensions/extensions.js
@@ -1,4 +1,4 @@
-const taskUserActions = ['commentTask', 'completeTaskAssigned', 'completeTaskCoworker', 'createNewTask', 'updateTask'];
+const taskUserActions = ['commentTask', 'completeTask', 'completeTaskAssigned', 'completeTaskCoworker', 'createNewTask', 'updateTask'];
 export function init() {
   extensionRegistry.registerExtension('engagementCenterActions', 'user-actions', {
     type: 'task',

--- a/webapps/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskChangesDrawer.vue
+++ b/webapps/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskChangesDrawer.vue
@@ -117,7 +117,7 @@ export default {
     },
     renderChangeHTML(item) {
       let str = '';
-      if ( item.actionName === 'assign' || item.actionName === 'unassign') {
+      if (item.actionName === 'assign' || item.actionName === 'unassign' || item.actionName === 'assignCoworker' || item.actionName === 'unassignCoworker') {
         const targetFullName = item.isTargetFullNameExternal ? `${item.targetFullName} (${this.$t('label.external')})` :  `${item.targetFullName}`;
         str = `<p class='text-truncate my-auto text-color ms-1 subtitle-2' title='${item.authorFullName} ${this.$t(this.logMsg(item))} ${targetFullName}'>` +
             `<span>${ this.$t(this.logMsg(item))}</span>`+


### PR DESCRIPTION
This change will add a dedicated Log entry in Tasks for corworker assignment as done for Assignee field. In addition, the gamified events 'completeTaskAssigned' and 'completeTaskCoworker' are applied, by this change, to all previously assigned users even when it's not assigned when the task is archived. Furthermore, a new dedicated event 'completeTask' has been added to gamify the 'Mark as archived' action that is not considered as a 'updateTask' event.