### PR TITLE
fix: Error when trying to add a comment in task with curl - EXO-65882 - Meeds-io/meeds#1067

### DIFF
--- a/services/src/main/java/org/exoplatform/task/rest/TaskRestService.java
+++ b/services/src/main/java/org/exoplatform/task/rest/TaskRestService.java
@@ -835,6 +835,7 @@ public class TaskRestService implements ResourceContainer {
   @POST
   @Path("comments/{id}")
   @RolesAllowed("users")
+  @Produces(MediaType.APPLICATION_JSON)
   @Operation(summary = "Adds comment to a specific task by id", method = "POST", description = "This Adds comment to a specific task by id")
   @ApiResponses(value = { 
           @ApiResponse(responseCode = "200", description = "Request fulfilled"),
@@ -872,6 +873,7 @@ public class TaskRestService implements ResourceContainer {
 
   @POST
   @Path("comments/{commentId}/{id}")
+  @Produces(MediaType.APPLICATION_JSON)
   @RolesAllowed("users")
   @Operation(summary = "Adds a sub comment to a specific parent comment by id and a specific task by id", method = "POST", description = "This Adds sub comment to a parent comment in specific task by id")
   @ApiResponses(value = { 


### PR DESCRIPTION
Before this fix, when you add a comment in a task with curl (without Accept header), there is an error in log This fix add the @Produces annotation, so that the response have the correct mimetype

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
