### PR TITLE
fix: Fix Task Mention content generation - MEED-2529 - Meeds-io/MIPs#80

### DIFF
--- a/services/src/main/java/org/exoplatform/task/integration/notification/AbstractNotificationPlugin.java
+++ b/services/src/main/java/org/exoplatform/task/integration/notification/AbstractNotificationPlugin.java
@@ -29,6 +29,7 @@ import org.exoplatform.container.PortalContainer;
 import org.exoplatform.container.RootContainer;
 import org.exoplatform.container.component.RequestLifeCycle;
 import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.portal.config.UserPortalConfigService;
 import org.exoplatform.services.organization.OrganizationService;
 import org.exoplatform.task.dto.ProjectDto;
 import org.exoplatform.task.dto.TaskDto;
@@ -126,6 +127,10 @@ public abstract class AbstractNotificationPlugin extends BaseNotificationPlugin 
       receivers.removeIf(user -> !ProjectUtil.isProjectParticipant(organizationService, user, project));
     }
     return receivers;
+  }
+
+  protected String getPortalOwner() {
+    return CommonsUtils.getService(UserPortalConfigService.class).getDefaultPortal();
   }
 
   private String buildTaskUrl(TaskDto t, ExoContainer container, WebAppController controller) {

--- a/services/src/main/java/org/exoplatform/task/integration/notification/TaskCommentPlugin.java
+++ b/services/src/main/java/org/exoplatform/task/integration/notification/TaskCommentPlugin.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import org.exoplatform.commons.api.notification.NotificationContext;
 import org.exoplatform.commons.api.notification.model.NotificationInfo;
 import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.social.core.utils.MentionUtils;
 import org.exoplatform.task.dto.CommentDto;
 import org.exoplatform.task.dto.TaskDto;
 
@@ -48,7 +49,7 @@ public class TaskCommentPlugin extends AbstractNotificationPlugin {
     CommentDto comment = ctx.value(NotificationUtils.COMMENT);
     NotificationInfo info = super.makeNotification(ctx);
     info.with(NotificationUtils.TASKS, String.valueOf(task.getId()));
-    info.with(NotificationUtils.COMMENT_TEXT, comment.getComment());
+    info.with(NotificationUtils.COMMENT_TEXT, MentionUtils.substituteUsernames(getPortalOwner(), comment.getComment()));
     // Override the activityId
     String projectId = "project.";
     if (task.getStatus() != null && task.getStatus().getProject() != null) {

--- a/services/src/main/java/org/exoplatform/task/integration/notification/TaskMentionPlugin.java
+++ b/services/src/main/java/org/exoplatform/task/integration/notification/TaskMentionPlugin.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import org.exoplatform.commons.api.notification.NotificationContext;
 import org.exoplatform.commons.api.notification.model.NotificationInfo;
 import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.social.core.utils.MentionUtils;
 import org.exoplatform.task.dto.CommentDto;
 import org.exoplatform.task.dto.TaskDto;
 
@@ -47,7 +48,7 @@ public class TaskMentionPlugin extends AbstractNotificationPlugin {
     TaskDto task = ctx.value(NotificationUtils.TASK);
     CommentDto comment = ctx.value(NotificationUtils.COMMENT);
     NotificationInfo info = super.makeNotification(ctx);
-    info.with(NotificationUtils.COMMENT_TEXT, comment.getComment());
+    info.with(NotificationUtils.COMMENT_TEXT, MentionUtils.substituteUsernames(getPortalOwner(), comment.getComment()));
     // Override the activityId
     String projectId = "project.";
     if (task.getStatus() != null && task.getStatus().getProject() != null) {


### PR DESCRIPTION
Prior to this change, the content of Task in notification was mentioning the username instead of the User Full name. This change will ensure to change to use the full name in Task Comment Message instead of user mentioning.