### PR TITLE
fix: Fix Task Comment and description WYSIWYG style - MEED-2534 - Meeds-io/meeds#1102

### DIFF
--- a/webapps/src/main/webapp/vue-app/taskCommentsDrawer/components/TaskCommentItem.vue
+++ b/webapps/src/main/webapp/vue-app/taskCommentsDrawer/components/TaskCommentItem.vue
@@ -49,8 +49,8 @@
       </div>
       <div class="commentBody ms-10 mt-1">
         <div
-          class="taskContentComment"
-          v-html="comment.formattedComment"></div>
+          class="taskContentComment reset-style-box rich-editor-content"
+          v-sanitized-html="comment.formattedComment"></div>
         <v-btn
           id="reply_btn"
           depressed

--- a/webapps/src/main/webapp/vue-app/taskCommentsDrawer/components/TaskLastComment.vue
+++ b/webapps/src/main/webapp/vue-app/taskCommentsDrawer/components/TaskLastComment.vue
@@ -33,8 +33,8 @@
     </div>
     <div class="commentBody ms-10 mt-1">
       <div
-        class="taskContentComment"
-        v-html="comment.formattedComment"></div>
+        class="taskContentComment reset-style-box rich-editor-content"
+        v-sanitized-html="comment.formattedComment"></div>
       <v-btn
         id="reply_btn"
         depressed

--- a/webapps/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskChangesDrawer.vue
+++ b/webapps/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskChangesDrawer.vue
@@ -50,7 +50,7 @@
                     :url="null"
                     popover 
                     align-top />
-                  <div class="d-flex mt-n2" v-html="renderChangeHTML(item)"></div>
+                  <div class="d-flex mt-n2" v-sanitized-html="renderChangeHTML(item)"></div>
                 </div>
                 <div>
                   <div class="dateTime caption px-10 my-n3">

--- a/webapps/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskDescriptionEditor.vue
+++ b/webapps/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskDescriptionEditor.vue
@@ -21,12 +21,12 @@
       :class="editorReady && 'active'"
       class="taskDescription richEditor">
       <div
+        v-sanitized-html="value"
         :data-text="placeholder"
         :title="$t('tooltip.clickToEdit')"
         contentEditable="true"
-        class="py-1 px-2 taskDescriptionToShow"
-        @click="showDescriptionEditor($event)"
-        v-sanitized-html="value">
+        class="py-1 px-2 taskDescriptionToShow reset-style-box rich-editor-content"
+        @click="showDescriptionEditor($event)">
         {{ placeholder }}
       </div>
 

--- a/webapps/src/main/webapp/vue-app/taskSearch/components/TaskSearchCard.vue
+++ b/webapps/src/main/webapp/vue-app/taskSearch/components/TaskSearchCard.vue
@@ -20,10 +20,10 @@
     flat
     min-height="227">
     <a
+      v-sanitized-html="taskTitle"
       :title="taskTitleText"
       class="px-3 pt-2 pb-1 text-left text-truncate"
-      @click="openTaskDrawer"
-      v-html="taskTitle">
+      @click="openTaskDrawer">
     </a>
     <div class="mx-auto d-flex flex-grow-1 px-3 py-0">
       <div


### PR DESCRIPTION
Prior to this change, the Task comments were using v-html instead of v-sanitized-html directive which ensures the security of displayed html in front end and harmonizes the style of displayed html.