### PR TITLE
feat: Mention cannot be done in task description - MEED-2541- Meeds-io/MIPs#53

### DIFF
--- a/webapps/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskDescriptionEditor.vue
+++ b/webapps/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskDescriptionEditor.vue
@@ -47,7 +47,8 @@
         :tag-enabled="false"
         ck-editor-type="taskContent"
         object-type="task"
-        autofocus />
+        autofocus
+        disable-suggester />
     </div>
     <v-btn
       v-if="task.id && displayEditor && editorReady"


### PR DESCRIPTION
This PR allows to disable the suggester option in the task description editor