### PR TITLE
fix : Preventing the apply button from triggering the blur event of the task editor description - EXO-66080 Meeds-io/meeds#1105 (#249)

### DIFF
--- a/webapps/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskDescriptionEditor.vue
+++ b/webapps/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskDescriptionEditor.vue
@@ -201,9 +201,12 @@ export default {
         startupFocus: self.inputVal=== '' ? true :'end',
         autoGrow_onStartup: true,
         on: {
-          blur: function () {
-            $(document.body).trigger('click');
-            self.hideDescriptionEditor();
+          blur: function (event) {
+            const doc = event.editor.container.$.ownerDocument;
+            if (doc.activeElement.id.toString() !== 'saveDescriptionButton'){
+              $(document.body).trigger('click');
+              self.hideDescriptionEditor();
+            }
           },
           change: function(evt) {
             const newData = evt.editor.getData();


### PR DESCRIPTION


Prior to this change the task description was not saved when clicking on the apply button by force. This issue was caused by the blur event of the task description editor. This fix addresses this issue by preventing the apply button from triggering the blur event of the editor description

