### PR TITLE
feat:Add an information in task history when adding images - MEED-2437 - Meeds-io/MIPs#53

### DIFF
--- a/services/src/main/java/org/exoplatform/task/integration/TaskAttachmentLoggingListener.java
+++ b/services/src/main/java/org/exoplatform/task/integration/TaskAttachmentLoggingListener.java
@@ -1,3 +1,21 @@
+/**
+ * This file is part of the Meeds project (https://meeds.io/).
+ *
+ * Copyright (C) 2023 Meeds Association contact@meeds.io
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
 package org.exoplatform.task.integration;
 
 import org.exoplatform.services.listener.Event;
@@ -20,12 +38,8 @@ public class TaskAttachmentLoggingListener extends Listener<String, ObjectAttach
     String username = event.getSource();
     ObjectAttachmentId objectAttachment = event.getData();
 
-    if (objectAttachment == null) {
-      return;
+    if (objectAttachment != null && ATTACHMENT_TASK_OBJECT_TYPE.equals(objectAttachment.getObjectType())) {
+      taskService.addTaskLog(Long.parseLong(objectAttachment.getObjectId()), username, "attach_image", "");
     }
-    if (!objectAttachment.getObjectType().equals(ATTACHMENT_TASK_OBJECT_TYPE)) {
-      return;
-    }
-    taskService.addTaskLog(Long.parseLong(objectAttachment.getObjectId()), username, "attach_image", "");
   }
 }

--- a/services/src/main/java/org/exoplatform/task/integration/TaskAttachmentLoggingListener.java
+++ b/services/src/main/java/org/exoplatform/task/integration/TaskAttachmentLoggingListener.java
@@ -3,16 +3,18 @@ package org.exoplatform.task.integration;
 import org.exoplatform.services.listener.Event;
 import org.exoplatform.services.listener.Listener;
 import org.exoplatform.social.attachment.model.ObjectAttachmentId;
+import org.exoplatform.task.service.TaskService;
 
 public class TaskAttachmentLoggingListener extends Listener<String, ObjectAttachmentId> {
 
   public static final String ATTACHMENT_TASK_OBJECT_TYPE = "task";
 
-  private org.exoplatform.task.service.TaskService taskService;
+  private final TaskService taskService;
 
-  public TaskAttachmentLoggingListener(org.exoplatform.task.service.TaskService taskService) {
+  public TaskAttachmentLoggingListener(TaskService taskService) {
     this.taskService = taskService;
   }
+
   @Override
   public void onEvent(Event<String, ObjectAttachmentId> event) throws Exception {
     String username = event.getSource();

--- a/services/src/main/java/org/exoplatform/task/integration/TaskAttachmentLoggingListener.java
+++ b/services/src/main/java/org/exoplatform/task/integration/TaskAttachmentLoggingListener.java
@@ -1,0 +1,29 @@
+package org.exoplatform.task.integration;
+
+import org.exoplatform.services.listener.Event;
+import org.exoplatform.services.listener.Listener;
+import org.exoplatform.social.attachment.model.ObjectAttachmentId;
+
+public class TaskAttachmentLoggingListener extends Listener<String, ObjectAttachmentId> {
+
+  public static final String ATTACHMENT_TASK_OBJECT_TYPE = "task";
+
+  private org.exoplatform.task.service.TaskService taskService;
+
+  public TaskAttachmentLoggingListener(org.exoplatform.task.service.TaskService taskService) {
+    this.taskService = taskService;
+  }
+  @Override
+  public void onEvent(Event<String, ObjectAttachmentId> event) throws Exception {
+    String username = event.getSource();
+    ObjectAttachmentId objectAttachment = event.getData();
+
+    if (objectAttachment == null) {
+      return;
+    }
+    if (!objectAttachment.getObjectType().equals(ATTACHMENT_TASK_OBJECT_TYPE)) {
+      return;
+    }
+    taskService.addTaskLog(Long.parseLong(objectAttachment.getObjectId()), username, "attach_image", "");
+  }
+}

--- a/webapps/src/main/resources/locale/portlet/taskManagement_en.properties
+++ b/webapps/src/main/resources/locale/portlet/taskManagement_en.properties
@@ -291,6 +291,7 @@ log.edit_title=edited title
 log.edit_workplan=edited work plan
 log.mark_done=archived this task
 log.edit_priority=changed priority to
+log.attach_image=has added images to the description
 
 #pageIterator
 pageIterator.label.previous=previous

--- a/webapps/src/main/webapp/WEB-INF/conf/task-addon/social-configuration.xml
+++ b/webapps/src/main/webapp/WEB-INF/conf/task-addon/social-configuration.xml
@@ -75,6 +75,11 @@
       <type>org.exoplatform.task.integration.TaskLoggingListener</type>
     </component-plugin>
     <component-plugin>
+      <name>attachment.created</name>
+      <set-method>addListener</set-method>
+      <type>org.exoplatform.task.integration.TaskAttachmentLoggingListener</type>
+    </component-plugin>
+    <component-plugin>
       <name>exo.task.taskCommentCreation</name>
       <set-method>addListener</set-method>
       <type>org.exoplatform.task.integration.TaskCommentNotificationListener</type>


### PR DESCRIPTION
This PR adds an new log to the task changes drawer when attaching a new image to the task description.