### PR TITLE
feat: Add information in task history when removing images - MEED-2561-Meeds-io/MIPs#53

### DIFF
--- a/services/src/main/java/org/exoplatform/task/integration/TaskAttachmentLoggingListener.java
+++ b/services/src/main/java/org/exoplatform/task/integration/TaskAttachmentLoggingListener.java
@@ -27,6 +27,10 @@ public class TaskAttachmentLoggingListener extends Listener<String, ObjectAttach
 
   public static final String ATTACHMENT_TASK_OBJECT_TYPE = "task";
 
+  public static final String ATTACHMENT_CREATED_EVENT = "attachment.created";
+
+  public static final String ATTACHMENT_DELETED_EVENT = "attachment.deleted";
+
   private final TaskService taskService;
 
   public TaskAttachmentLoggingListener(TaskService taskService) {
@@ -39,7 +43,18 @@ public class TaskAttachmentLoggingListener extends Listener<String, ObjectAttach
     ObjectAttachmentId objectAttachment = event.getData();
 
     if (objectAttachment != null && ATTACHMENT_TASK_OBJECT_TYPE.equals(objectAttachment.getObjectType())) {
-      taskService.addTaskLog(Long.parseLong(objectAttachment.getObjectId()), username, "attach_image", "");
+      switch (event.getEventName()) {
+      case ATTACHMENT_CREATED_EVENT: {
+        taskService.addTaskLog(Long.parseLong(objectAttachment.getObjectId()), username, "attach_image", "");
+        break;
+      }
+      case ATTACHMENT_DELETED_EVENT: {
+        taskService.addTaskLog(Long.parseLong(objectAttachment.getObjectId()), username, "delete_image", "");
+        break;
+      }
+      default:
+        throw new IllegalArgumentException("Unexpected listener event name: " + event.getEventName());
+      }
     }
   }
 }

--- a/webapps/src/main/resources/locale/portlet/taskManagement_en.properties
+++ b/webapps/src/main/resources/locale/portlet/taskManagement_en.properties
@@ -292,6 +292,7 @@ log.edit_workplan=edited work plan
 log.mark_done=archived this task
 log.edit_priority=changed priority to
 log.attach_image=has added images to the description
+log.delete_image=has removed images from the description
 
 #pageIterator
 pageIterator.label.previous=previous

--- a/webapps/src/main/webapp/WEB-INF/conf/task-addon/social-configuration.xml
+++ b/webapps/src/main/webapp/WEB-INF/conf/task-addon/social-configuration.xml
@@ -80,6 +80,11 @@
       <type>org.exoplatform.task.integration.TaskAttachmentLoggingListener</type>
     </component-plugin>
     <component-plugin>
+      <name>attachment.deleted</name>
+      <set-method>addListener</set-method>
+      <type>org.exoplatform.task.integration.TaskAttachmentLoggingListener</type>
+    </component-plugin>
+    <component-plugin>
       <name>exo.task.taskCommentCreation</name>
       <set-method>addListener</set-method>
       <type>org.exoplatform.task.integration.TaskCommentNotificationListener</type>


### PR DESCRIPTION
This PR adds an new log to the task changes drawer when removing an attached image from the task description.