### PR TITLE
fix: Clear Task Drawer UI components on close - MEED-2643 - Meeds-io/meeds#1154

### DIFF
--- a/webapps/src/main/webapp/vue-app/taskCommentsDrawer/components/TaskCommentItem.vue
+++ b/webapps/src/main/webapp/vue-app/taskCommentsDrawer/components/TaskCommentItem.vue
@@ -53,10 +53,11 @@
           class="taskContentComment reset-style-box rich-editor-content"
           v-sanitized-html="comment.formattedComment"></div>
          <attachments-image-items
-            :object-id="comment.comment.id"
-            object-type="taskComment"
-            :preview-width="250"
-            :preview-height="250" />
+           v-if="comment.comment.id"
+           :object-id="comment.comment.id"
+           :preview-width="250"
+           :preview-height="250"
+           object-type="taskComment" />
         <v-btn
           id="reply_btn"
           depressed

--- a/webapps/src/main/webapp/vue-app/taskCommentsDrawer/components/TaskLastComment.vue
+++ b/webapps/src/main/webapp/vue-app/taskCommentsDrawer/components/TaskLastComment.vue
@@ -37,6 +37,7 @@
         class="taskContentComment reset-style-box rich-editor-content"
         v-sanitized-html="comment.formattedComment"></div>
       <attachments-image-items
+        v-if="comment.comment.id"
         :object-id="comment.comment.id"
         :preview-width="250"
         :preview-height="250"

--- a/webapps/src/main/webapp/vue-app/taskDrawer/components/TaskDrawer.vue
+++ b/webapps/src/main/webapp/vue-app/taskDrawer/components/TaskDrawer.vue
@@ -32,8 +32,8 @@
       body-classes="hide-scroll decrease-z-index-more"
       right
       @closed="onCloseDrawer">
-      <template 
-        v-if="task && task.id"
+      <template
+        v-if="drawer && task?.id"
         slot="title">
         <div class="drawerTitleAndProject d-flex">
           <i
@@ -66,7 +66,7 @@
           </v-menu>
         </div>
       </template>
-      <template v-else slot="title">
+      <template v-else-if="drawer" slot="title">
         <div class="drawerTitleAndProject d-flex">
           <i
             v-if="addBackArrow"
@@ -80,7 +80,7 @@
           </div>
         </div>
       </template>
-      <template slot="content">
+      <template v-if="drawer" slot="content">
         <div class="taskDrawerDetails pa-4">
           <div class="taskTitleAndMark d-flex">
             <v-btn
@@ -227,6 +227,7 @@ export default {
     return {
       displayActionMenu: false,
       menuActions: [],
+      drawer: false,
       reset: false,
       dates: [],
       commentPlaceholder: this.$t('comment.message.addYourComment'),

--- a/webapps/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskDescriptionEditor.vue
+++ b/webapps/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskDescriptionEditor.vue
@@ -31,10 +31,11 @@
           {{ placeholder }}
         </div>
         <attachments-image-items
+          v-if="metadataObjectId"
           :object-id="metadataObjectId"
-          object-type="task"
           :preview-width="250"
-          :preview-height="250" />
+          :preview-height="250"
+          object-type="task" />
       </div>
       <rich-editor
         v-if="editorReady"


### PR DESCRIPTION
Prior to this change, the UI components of Task drawer were kept alive and refreshed on Task open which can lead to inconsistency while Task isn't completely loaded yet. This change will delete UI Component instances on drawer closing to force refresh when reopened.