### PR TITLE
fix: Fix Task Label Text truncation - MEED-2664 - Meeds-io/meeds#1065

### DIFF
--- a/webapps/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TaskViewCard.vue
+++ b/webapps/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TaskViewCard.vue
@@ -78,6 +78,7 @@
             <div
               v-if="task.labels && task.labels.length"
               :class="getClassLabels()"
+              class="text-truncate rounded"
               @click="openTaskDrawer()">
               <v-chip
                 v-if="task.labels && task.labels.length == 1"

--- a/webapps/src/main/webapp/vue-app/tasks-management/components/tasks/TaskCard.vue
+++ b/webapps/src/main/webapp/vue-app/tasks-management/components/tasks/TaskCard.vue
@@ -76,6 +76,7 @@
           <div
             v-if="task.labels && task.labels.length"
             :class="getClassLabels()"
+            class="text-truncate rounded"
             @click="openTaskDrawer()">
             <v-chip
               v-if="task.labels && task.labels.length == 1"


### PR DESCRIPTION
Prior to this change, the Task label is displayed over the due date. This change will add text truncation on labels to avoid this.