### PR TITLE
fix: Participants Are Only Mentioned - MEED-2689 - Meeds-io/meeds#1168

### DIFF
--- a/webapps/src/main/webapp/vue-app/taskCommentsDrawer/components/TaskCommentEditor.vue
+++ b/webapps/src/main/webapp/vue-app/taskCommentsDrawer/components/TaskCommentEditor.vue
@@ -31,7 +31,7 @@
         :placeholder="placeholder"
         :object-id="newCommentId"
         :tag-enabled="false"
-        :suggester-space-url="taskSpaceUrl"
+        :suggester-space-u-r-l="taskSpaceUrl"
         ck-editor-type="taskCommentContent"
         object-type="taskComment"
         autofocus

--- a/webapps/src/main/webapp/vue-app/taskCommentsDrawer/components/TaskCommentEditor.vue
+++ b/webapps/src/main/webapp/vue-app/taskCommentsDrawer/components/TaskCommentEditor.vue
@@ -31,6 +31,7 @@
         :placeholder="placeholder"
         :object-id="newCommentId"
         :tag-enabled="false"
+        :suggester-space-url="getSpaceUrlFromProjectParticipator()"
         ck-editor-type="taskCommentContent"
         object-type="taskComment"
         autofocus
@@ -197,6 +198,15 @@ export default {
       this.$emit('attachments-edited');
       if (attachments?.length) {
         this.taskCommentAttachmentsEdited = true;
+      }
+    },
+    getSpaceUrlFromProjectParticipator() {
+      const participator = this.task.status.project.participator;
+      if (participator && participator.length > 0) {
+        const projectParticipator = participator.find((element) => element.startsWith('member:/spaces/'));
+        if (projectParticipator) {
+          return projectParticipator.substring(15);
+        }
       }
     },
   },

--- a/webapps/src/main/webapp/vue-app/taskCommentsDrawer/components/TaskCommentEditor.vue
+++ b/webapps/src/main/webapp/vue-app/taskCommentsDrawer/components/TaskCommentEditor.vue
@@ -31,7 +31,7 @@
         :placeholder="placeholder"
         :object-id="newCommentId"
         :tag-enabled="false"
-        :suggester-space-url="getSpaceUrlFromProjectParticipator()"
+        :suggester-space-url="taskSpaceUrl"
         ck-editor-type="taskCommentContent"
         object-type="taskComment"
         autofocus
@@ -123,6 +123,16 @@ export default {
     postDisabled() {
       return !this.validMessage || (!this.inputVal && !this.taskCommentAttachmentsEdited);
     },
+    taskSpaceUrl() {
+      const projectMembers = this.task?.status?.project?.participator;
+      if (projectMembers?.length) {
+        const projectSpace = projectMembers.find(member => member.includes('/spaces/'));
+        if (projectSpace) {
+          return projectSpace.split('/spaces/')[1];
+        }
+      }
+      return null;
+    },
   },
   mounted() {
     this.$root.$on('task-comment-created', () => {
@@ -198,15 +208,6 @@ export default {
       this.$emit('attachments-edited');
       if (attachments?.length) {
         this.taskCommentAttachmentsEdited = true;
-      }
-    },
-    getSpaceUrlFromProjectParticipator() {
-      const participator = this.task.status.project.participator;
-      if (participator && participator.length > 0) {
-        const projectParticipator = participator.find((element) => element.startsWith('member:/spaces/'));
-        if (projectParticipator) {
-          return projectParticipator.substring(15);
-        }
       }
     },
   },


### PR DESCRIPTION
Prior to this change non members / non participants of a task project related to a space, can be mentioned while adding a task comment in the general task app /portal/meeds/tasks. This change will make sure only project participants can be mentioned in the general task app.

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
