### PR TITLE
feat: Reuse centralized Toast Notifs component - MEED-2627 - Meeds-io/MIPs#99

### DIFF
--- a/webapps/src/main/webapp/vue-app/tasks-management/components/TasksManagement.vue
+++ b/webapps/src/main/webapp/vue-app/tasks-management/components/TasksManagement.vue
@@ -16,13 +16,6 @@
 -->
 <template>
   <v-app id="TasksManagementPortlet">
-    <v-alert 
-      v-model="alert" 
-      :type="type"
-      dismissible>
-      {{ message }}
-    </v-alert>
-
     <v-tabs 
       v-if="showTabs"
       v-model="tab"
@@ -62,9 +55,6 @@ export default {
       showTabs: false,
       spaceName: '',
       projectId: '',
-      alert: false,
-      type: '',
-      message: '',
       task: {
         type: Object,
         default: () => ({}),
@@ -77,9 +67,7 @@ export default {
     }
   },
   created(){
-    this.$root.$on('show-alert', message => {
-      this.displayMessage(message);
-    });
+    this.$root.$on('show-alert', this.displayMessage);
     this.$root.$on('open-project-drawer', project => {
       this.$refs.addProjectDrawer.open(project);
     });
@@ -198,10 +186,7 @@ export default {
       window.history.pushState('task', 'Task details', `${urlPath.split('tasks')[0]}tasks/projectDetail/${id}`); 
     },
     displayMessage(message) {
-      this.message=message.message;
-      this.type=message.type;
-      this.alert = true;
-      window.setTimeout(() => this.alert = false, 5000);
+      this.$root.$emit('alert-message', message?.message, message?.type || 'success');
     }
   }
 };

--- a/webapps/src/main/webapp/vue-app/tasks/components/TasksApp.vue
+++ b/webapps/src/main/webapp/vue-app/tasks/components/TasksApp.vue
@@ -19,12 +19,6 @@
     id="tasks"
     class="VuetifyApp"
     flat>
-    <v-alert
-      v-model="alert"
-      :type="type"
-      dismissible>
-      {{ message }}
-    </v-alert>
     <v-container white pa-0>
       <v-layout
         row
@@ -196,9 +190,6 @@ export default {
         description: '',
         title: ''
       },
-      alert: false,
-      type: '',
-      message: '',
       priorityStatus: ['High', 'In Normal', 'Low', 'None', null],
     };
   },computed: {
@@ -252,9 +243,7 @@ export default {
       this.getMyTomorrowTasks();
       this.getMyUpcomingTasks();
     });
-    this.$root.$on('show-alert', message => {
-      this.displayMessage(message);
-    });
+    this.$root.$on('show-alert', this.displayMessage);
     this.$root.$on('open-task-drawer', task => {
       this.task=task;
       this.$refs.taskDrawer.open(this.task);
@@ -393,10 +382,7 @@ export default {
       }
     },
     displayMessage(message) {
-      this.message=message.message;
-      this.type=message.type;
-      this.alert = true;
-      window.setTimeout(() => this.alert = false, 5000);
+      this.$root.$emit('alert-message', message?.message, message?.type || 'success');
     }
   }
 };


### PR DESCRIPTION
Prior to this change, the toast notifications defined in Tasks wasn't relying on the centralized reusable component to display alerts. This change removes the specific alerts added to Tasks application in order to reuse the centralized component.