### PR TITLE
fix: Participants Are Only Mentioned - MEED-2689 - Meeds-io/meeds#1168

### DIFF
--- a/webapps/src/main/webapp/vue-app/taskCommentsDrawer/components/TaskCommentEditor.vue
+++ b/webapps/src/main/webapp/vue-app/taskCommentsDrawer/components/TaskCommentEditor.vue
@@ -31,6 +31,7 @@
         :placeholder="placeholder"
         :object-id="newCommentId"
         :tag-enabled="false"
+        :suggester-space-u-r-l="taskSpaceUrl"
         ck-editor-type="taskCommentContent"
         object-type="taskComment"
         autofocus
@@ -121,6 +122,16 @@ export default {
   computed: {
     postDisabled() {
       return !this.validMessage || (!this.inputVal && !this.taskCommentAttachmentsEdited);
+    },
+    taskSpaceUrl() {
+      const projectMembers = this.task?.status?.project?.participator;
+      if (projectMembers?.length) {
+        const projectSpace = projectMembers.find(member => member.includes('/spaces/'));
+        if (projectSpace) {
+          return projectSpace.split('/spaces/')[1];
+        }
+      }
+      return null;
     },
   },
   mounted() {


### PR DESCRIPTION
Prior to this change non members / non participants of a task project related to a space, can be mentioned while adding a task comment in the general task app /portal/meeds/tasks. This change will make sure only project participants can be mentioned in the general task app.