### PR TITLE
fix: Task Labels Suggestor Still Displayed - MEED-2773 - Meeds-io/meeds#1208

### DIFF
--- a/webapps/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskProject.vue
+++ b/webapps/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskProject.vue
@@ -114,7 +114,7 @@ export default {
   created() {
     this.getProjects();
     $(document).on('mousedown', () => {
-      if (this.$refs.select.isMenuActive) {
+      if (this.$refs.select && this.$refs.select.isMenuActive) {
         window.setTimeout(() => {
           this.$refs.select.isMenuActive = false;
         }, 200);


### PR DESCRIPTION
Prior to this change the label suggestor remains displayed once you have added a label or removed one. This change makes sure that once you have added a label, the suggestor collapses, and once you have removed a label, the suggestor collapses.

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
