### PR TITLE
fix: Task Comment Composer Not Displayed - MEED-2774 - Meeds-io/meeds#1184

### DIFF
--- a/webapps/src/main/webapp/vue-app/taskCommentsDrawer/components/TaskCommentEditor.vue
+++ b/webapps/src/main/webapp/vue-app/taskCommentsDrawer/components/TaskCommentEditor.vue
@@ -196,7 +196,6 @@ export default {
     },
     reset() {
       this.inputVal = '';
-      this.editorReady = false;
       this.taskCommentAttachmentsEdited = false;
     },
     saveAttachments(commentId) {


### PR DESCRIPTION
Prior to this change when there is no comment and you close the composer then request again to add a new comment without reloading the page, you cannot add any comment. This change makes sure that the comment composer is displayed all the time when there is no comment.

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
