### PR TITLE
fix: Task comments are not working - EXO-66946 - Meeds-io/meeds#1242

### DIFF
--- a/webapps/src/main/webapp/vue-app/taskCommentsDrawer/components/TaskCommentsDrawer.vue
+++ b/webapps/src/main/webapp/vue-app/taskCommentsDrawer/components/TaskCommentsDrawer.vue
@@ -19,6 +19,7 @@
     <exo-drawer
       @closed="closeDrawer"
       id="taskCommentDrawer"
+      v-model="drawer"
       class="taskCommentDrawer"
       ref="taskCommentDrawer"
       right>
@@ -62,7 +63,7 @@
                 @confirmDialogClosed="$emit('confirmDialogClosed')" />
             </div>
           </div>
-          <div v-else>
+          <div v-else-if="drawer">
             <div class="editorContent commentEditorContainer newCommentEditor">
               <task-comment-editor
                 ref="commentEditor"
@@ -108,6 +109,7 @@ export default {
     return {
       commentId: '',
       showNewCommentEditor: false,
+      drawer: false,
       test: false,
       MESSAGE_MAX_LENGTH: 1300,
       newComment: null,


### PR DESCRIPTION
Prior to this change, when you open the task comments drawer and close it or click the back arrow and then open the task comments drawer again, task comments cannot be added. To solve this problem, when closing this drawer, it falsely overwrites the DOM drawer using v-if and takes it as conditions attribute the state of the drawer, that's why it has to add an attribute of the drawer which changes with the change of the drawer. After this change, the rich editor works correctly and is reset the second time the drawer is opened.

(cherry picked from commit 55ffce021c9b1148c6dd309675b457cff1ada4d8)