### PR TITLE
fix: Fix used meta site name reference - MEED-3024 - Meeds-io/meeds#1351

### DIFF
--- a/webapps/src/main/webapp/vue-app/engagementCenterExtensions/extensions.js
+++ b/webapps/src/main/webapp/vue-app/engagementCenterExtensions/extensions.js
@@ -7,7 +7,7 @@ export function init() {
       icon: 'fas fa-tasks',
       match: (actionLabel) => taskUserActions.includes(actionLabel),
       getLink: (realization) => {
-        realization.link = `${eXo.env.portal.context}/${eXo.env.portal.defaultPortal}/tasks/taskDetail/${realization?.objectId}`;
+        realization.link = `${eXo.env.portal.context}/${eXo.env.portal.metaPortalName}/tasks/taskDetail/${realization?.objectId}`;
         return realization.link;
       }
     },


### PR DESCRIPTION
Prior to this change, the Meta site name was referenced as 'defaultPortal'. The notion of 'default' portal doesn't exist anymore and was replaced by 'meta' site with 'aggregated' sites. This change will replace to use the Meta site name where the list of referenced applications are added.