### PR TITLE
feat: Delete AppCenter Mandatory Flag - MEED-3034 - Meeds-io/meeds#1371

### DIFF
--- a/webapps/src/main/webapp/WEB-INF/conf/task-addon/app-center-configuration.xml
+++ b/webapps/src/main/webapp/WEB-INF/conf/task-addon/app-center-configuration.xml
@@ -49,19 +49,17 @@
               <string>Tasks application</string>
             </field>
             <field name="permissions">
-              <collection type="java.util.ArrayList" item-type="java.lang.String">
+              <collection type="java.util.ArrayList"
+                item-type="java.lang.String">
                 <value>
                   <string>*:/platform/users</string>
                 </value>
-				<value>
+                <value>
                   <string>*:/platform/externals</string>
                 </value>
               </collection>
-			</field>
-            <field name="active">
-              <boolean>true</boolean>
             </field>
-            <field name="isMandatory">
+            <field name="active">
               <boolean>true</boolean>
             </field>
             <field name="isMobile">


### PR DESCRIPTION
This change will delete mandatory flag from AppCenter application to let users choose it when needed instead of adding it systematically.