### PR TITLE
fix: Clear task search keyword when switching betwen projects and projectsTasksDetails - EXO-68620

### DIFF
--- a/webapps/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TasksViewToolbar.vue
+++ b/webapps/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TasksViewToolbar.vue
@@ -136,6 +136,7 @@ export default {
     this.$root.$on('hide-tasks-project', () => {
       $('a.v-tab').removeClass('v-tab--active');
       $('a.taskTabBoard').addClass('v-tab--active');
+      this.keyword = null ;
     });
   },
   methods: {


### PR DESCRIPTION
Before this change, after searching for a task and not clearing the word filter go to the project details and back to the tasks the word filter maintain
After this change, when switching between the views the keyword is reset