### PR TITLE
fix: Fix Dynamic Display of Task Topbar after adding first Task - MEED-3330 - Meeds-io/meeds#1627

### DIFF
--- a/webapps/src/main/webapp/vue-app/tasks-management/components/tasks/TasksDashboard.vue
+++ b/webapps/src/main/webapp/vue-app/tasks-management/components/tasks/TasksDashboard.vue
@@ -337,7 +337,7 @@ export default {
       if (tasksFilter.assignee) {
         tasksFilter.projectId = -2;
       }
-      
+
       return this.$tasksService.filterTasksList(tasksFilter,this.groupBy,this.orderBy,this.labels).then(data => {
         if (data.projectName){
           this.filterTaskQueryResult = data;
@@ -356,15 +356,18 @@ export default {
         if (this.tasksSize || this.filterActive) {
           this.displayToolbar = true;
         } else if (!this.showCompletedTasks && !this.displayToolbar && !this.loadingTasks) {
-          return this.$tasksService.filterTasksList({
-            projectId: this.filterTasks.projectId,
-            offset: 0,
-            limit: 1,
-            showCompletedTasks: true,
-          }).then(data => this.displayToolbar = data?.tasksNumber || false);
+          return this.checkExistingTasks();
         }
       })
         .finally(() => this.loadingTasks = false);
+    },
+    checkExistingTasks() {
+      return this.$tasksService.filterTasksList({
+        projectId: this.filterTasks.projectId,
+        offset: 0,
+        limit: 1,
+        showCompletedTasks: true,
+      }).then(data => this.displayToolbar = data?.tasksNumber || false);
     },
     getTasksByPrimary(primaryFilter) {
       this.primaryFilter=primaryFilter;         
@@ -543,12 +546,12 @@ export default {
     },
     updateTasksList() {
       this.$tasksService.filterTasksList(this.filterTasks, this.groupBy, this.orderBy, this.labels).then(data => {
-
         if (this.filterActive) {
           this.filterTaskQueryResult = data;
         } else {
           this.tasks = data.tasks;
         }
+        return this.checkExistingTasks();
       });
     },
     openTaskDrawer() {


### PR DESCRIPTION
Prior to this change, the Task Topbar isn't displayed just after adding a new Task. Thi change will add dynamic refresh of Topbar Display triggered by the Task creation event.