### PR TITLE
fix: Unable to update an task related action if from projects to any - MEED-3368 - Meeds-io/MIPs#105

### DIFF
--- a/webapps/src/main/webapp/vue-app/connectorEventExtensions/components/TaskEventForm.vue
+++ b/webapps/src/main/webapp/vue-app/connectorEventExtensions/components/TaskEventForm.vue
@@ -75,7 +75,7 @@ export default {
           projectIds: this.selected.map(project => project.id).toString(),
         };
         document.dispatchEvent(new CustomEvent('event-form-filled', {detail: eventProperties}));
-      } else {
+      } else if (this.project === 'ANY_IN_PROJECT') {
         document.dispatchEvent(new CustomEvent('event-form-unfilled'));
       }
     },


### PR DESCRIPTION
Before this change, the user could not update task action if he chose any.