### PR TITLE
fix: wrong number of tasks in project card detail - EXO-55498 - Meeds-io/meeds#1837

### DIFF
--- a/services/src/main/java/org/exoplatform/task/domain/Task.java
+++ b/services/src/main/java/org/exoplatform/task/domain/Task.java
@@ -153,7 +153,7 @@ import org.exoplatform.task.service.TaskBuilder;
         "AND (lower(ta.title) LIKE lower(:term)  OR lower(ta.description) LIKE :term) "
 )
 @NamedQuery(name = "Task.countTaskStatusByProject",
-        query = "SELECT m.status.name AS name, COUNT(m) AS total FROM TaskTask AS m where m.status.project.id = :projectId GROUP BY m.status.name ORDER BY m.status.name ASC")
+        query = "SELECT m.status.name AS name, COUNT(m) AS total FROM TaskTask AS m where m.status.project.id = :projectId and m.completed = false GROUP BY m.status.name ORDER BY m.status.name ASC")
 
 @NamedQuery(name = "Task.getByStatus",
         query = "SELECT t FROM TaskTask t  WHERE t.status.id = :statusid")


### PR DESCRIPTION
Before this change, the Completed tasks are included in the total number of tasks because of the non-check of their completed status
After this change, the completed status is checked and the completed tasks are not counted in the total number of tasks.