### PR TITLE
fix: Project detail labels can be out of screen when the status name is long - EXO-39839 - Meeds-io/meeds#1922

### DIFF
--- a/webapps/src/main/webapp/vue-app/tasks-management/components/Project/ProjectCardReverse.vue
+++ b/webapps/src/main/webapp/vue-app/tasks-management/components/Project/ProjectCardReverse.vue
@@ -83,6 +83,9 @@ export default {
       option: {
         tooltip: {
           trigger: 'item',
+          position: function (point) {
+            return { left: point[0] - 100};
+          },
           formatter: '{b}:<br/> {c} ({d}%)'
         },
         series: [


### PR DESCRIPTION
Before this change, when Go to tasks app, click on the information icon on that project card and hover on the donut pie chart, a tooltip will appear and when it's long and on the left side of the screen, it will not be fully displayed . After this change, The tooltip should be fully displayed.

(cherry picked from commit db543d693cb7505f674af92a23de77b4f5e6be41)