### PR TITLE
feat: Allow to add Emoji in spaces - MEED-4267 - Meeds-io/meeds#1777

### DIFF
--- a/services/src/main/resources/db/changelog/task.db.changelog-1.0.0.xml
+++ b/services/src/main/resources/db/changelog/task.db.changelog-1.0.0.xml
@@ -518,4 +518,10 @@
     </sql>
   </changeSet>
 
+  <changeSet author="task" id="1.0.0-36" dbms="mysql">
+    <sql>
+      ALTER TABLE TASK_PROJECTS MODIFY COLUMN NAME varchar(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    </sql>
+  </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
This change will allow to add emojis in Project Name, especially when the space name defines emojis. a special SQL modification is needed to make it possible on MySQL.