### PR TITLE
fix: Fix empty labels drawer & glitched display of filtered tasks after a task archive - EXO-67205 Meeds-io/meeds#2004 (#380)

### DIFF
--- a/webapps/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TasksViewDashboard.vue
+++ b/webapps/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TasksViewDashboard.vue
@@ -219,6 +219,7 @@ export default {
   data () {
     return {
       defaultAvatar: '/portal/rest/v1/social/users/default-image/avatar',
+      searchedLabels: [],
       keyword: null,
       loadingTasks: false,
       tasksFilter: {},
@@ -277,7 +278,7 @@ export default {
     });
 
     this.$root.$on('task-isCompleted-updated', task => {
-      this.$tasksService.filterTasksList(this.tasksFilter, '', '', '', this.project.id).then(data => {
+      this.$tasksService.filterTasksList(this.tasksFilter, '', '', this.searchedLabels, this.project.id).then(data => {
         if (Array.isArray(data.tasks[0])) {
 
           const showCompletedTaskFilter = {
@@ -417,6 +418,7 @@ export default {
       this.filterByStatus=false;
     },
     filterTaskDashboard(e) {
+      this.searchedLabels = e.filterLabels.labels;      
       this.loadingTasks = true;
       this.tasksFilter = e.tasks;
       this.showCompletedTasks = e.showCompletedTasks;

--- a/webapps/src/main/webapp/vue-app/tasks-management/components/tasks/TasksLabelsDrawer.vue
+++ b/webapps/src/main/webapp/vue-app/tasks-management/components/tasks/TasksLabelsDrawer.vue
@@ -84,6 +84,7 @@ export default {
       items: [],
       nonce: 1,
       model: [],
+      taskLabels: [],
       x: 0,
       search: null,
       y: 0,
@@ -133,11 +134,10 @@ export default {
     document.addEventListener('loadTaskLabels', event => {
       if (event && event.detail) {
         const task = event.detail;
-        this.model = [];
         if (task.id!=null) {
           this.getTaskLabels();
           this.$taskDrawerApi.getTaskLabels(task.id).then((labels) => {
-            this.model = labels.map(function (el) {
+            this.taskLabels = labels.map(function (el) {
               const o = Object.assign({}, el);
               o.text = o.name;
               return o;


### PR DESCRIPTION


prior to this change:
1)the labels drawer gets empty once task drawer gets opened 2)the results, when filtering tasks by labels, glitches once a task is archived

after this change:
1)undo reset of this.model so the searched labels remains maintained in the drawer
2)pass the parameter related to searched labels in filterTasksList method so only tasks with related labels would be displayed after archiving

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
