### PR TITLE
fix: Fix Display of Task Title to be on two lines - MEED-7103 - Meeds-io/meeds#2205

### DIFF
--- a/webapps/src/main/webapp/skin/css/tasks.less
+++ b/webapps/src/main/webapp/skin/css/tasks.less
@@ -2278,7 +2278,6 @@
   flex: 1 1 100%;
   overflow: hidden;
   text-overflow: ellipsis;
-  white-space: nowrap;
   margin-right: 10px ~'; /** orientation=lt */ ';
   margin-left: 10px ~'; /** orientation=rt */ ';
   cursor: pointer;


### PR DESCRIPTION
Prior to this change, the Task title was displayed on one single line in Board view. This change allows to apply Text truncation on two lines by deleting the CSS property 'white-space: nowrap'.

( Resolves Meeds-io/meeds#2205 )