### PR TITLE
feat: Redefine Parent applications Classes to fit layout style properties - MEED-7094 - Meeds-io/MIPs#144

### DIFF
--- a/webapps/src/main/webapp/WEB-INF/portlet.xml
+++ b/webapps/src/main/webapp/WEB-INF/portlet.xml
@@ -48,6 +48,10 @@
       <name>portlet-view-dispatched-file-path</name>
       <value>/html/tasksManagement.html</value>
     </init-param>
+    <init-param>
+      <name>layout-css-class</name>
+      <value>no-layout-background-color no-layout-border-radius no-layout-border</value>
+    </init-param>
     <supports>
       <mime-type>text/html</mime-type>
     </supports>

--- a/webapps/src/main/webapp/vue-app/connectorEventExtensions/components/TaskEvent.vue
+++ b/webapps/src/main/webapp/vue-app/connectorEventExtensions/components/TaskEvent.vue
@@ -17,7 +17,7 @@
  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 -->
 <template>
-  <v-app>
+  <div>
     <gamification-task-event-form
       v-if="isEditing"
       :trigger="trigger"
@@ -26,7 +26,7 @@
       v-else
       :trigger="trigger"
       :properties="properties" />
-  </v-app>
+  </div>
 </template>
 <script>
 export default {

--- a/webapps/src/main/webapp/vue-app/connectorEventExtensions/components/TaskEventDisplay.vue
+++ b/webapps/src/main/webapp/vue-app/connectorEventExtensions/components/TaskEventDisplay.vue
@@ -17,7 +17,7 @@
  Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 -->
 <template>
-  <v-app>
+  <div>
     <template v-if="projectIds">
       <div class="subtitle-1 font-weight-bold mb-2">
         {{ $t('gamification.event.display.doItNow') }}
@@ -44,7 +44,7 @@
         </v-btn>
       </div>
     </template>
-  </v-app>
+  </div>
 </template>
 
 <script>

--- a/webapps/src/main/webapp/vue-app/connectorEventExtensions/components/TaskEventForm.vue
+++ b/webapps/src/main/webapp/vue-app/connectorEventExtensions/components/TaskEventForm.vue
@@ -17,7 +17,7 @@ along with this program; if not, write to the Free Software Foundation,
 Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 -->
 <template>
-  <v-app>
+  <div>
     <v-card-text class="px-0 pb-0 dark-grey-color font-weight-bold">
       {{ $t('gamification.event.label.project') }}
     </v-card-text>
@@ -35,7 +35,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
         name="projectsSuggester"
         multiple />
     </v-radio-group>
-  </v-app>
+  </div>
 </template>
 
 <script>

--- a/webapps/src/main/webapp/vue-app/taskCommentsDrawer/components/TaskCommentsDrawer.vue
+++ b/webapps/src/main/webapp/vue-app/taskCommentsDrawer/components/TaskCommentsDrawer.vue
@@ -15,71 +15,69 @@
   Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 -->
 <template>
-  <v-app>
-    <exo-drawer
-      @closed="closeDrawer"
-      id="taskCommentDrawer"
-      v-model="drawer"
-      class="taskCommentDrawer"
-      ref="taskCommentDrawer"
-      right>
-      <template slot="title">
-        <v-flex
-          class="mx-0 drawerHeader flex-grow-0 width-full">
-          <v-list-item class="px-0">
-            <v-list-item-content class="drawerTitle d-flex text-header-title text-truncate">
-              <i class="uiIcon uiArrowBAckIcon" @click="closeDrawer"></i>
-              <span class="ps-2">{{ $t('label.comments') }}</span>
-            </v-list-item-content>
-            <v-list-item-action class="drawerIcons align-end d-flex flex-row">
-              <v-btn
-                :disabled="isEditorActive"
-                icon
-                :title="$t('comment.message.addYourComment')"
-                class="addCommentBtn float-right"
-                @click="openEditorToBottom(commentId)">
-                <i class="uiIcon uiIconTaskAddComment"></i>
-              </v-btn>
-            </v-list-item-action>
-          </v-list-item>
-        </v-flex>
-      </template>
-      <template slot="content">
-        <v-flex id="commentDrawerContent" class="drawerContent flex-grow-1 overflow-auto border-box-sizing">
+  <exo-drawer
+    @closed="closeDrawer"
+    id="taskCommentDrawer"
+    v-model="drawer"
+    class="taskCommentDrawer"
+    ref="taskCommentDrawer"
+    right>
+    <template slot="title">
+      <v-flex
+        class="mx-0 drawerHeader flex-grow-0 width-full">
+        <v-list-item class="px-0">
+          <v-list-item-content class="drawerTitle d-flex text-header-title text-truncate">
+            <i class="uiIcon uiArrowBAckIcon" @click="closeDrawer"></i>
+            <span class="ps-2">{{ $t('label.comments') }}</span>
+          </v-list-item-content>
+          <v-list-item-action class="drawerIcons align-end d-flex flex-row">
+            <v-btn
+              :disabled="isEditorActive"
+              icon
+              :title="$t('comment.message.addYourComment')"
+              class="addCommentBtn float-right"
+              @click="openEditorToBottom(commentId)">
+              <i class="uiIcon uiIconTaskAddComment"></i>
+            </v-btn>
+          </v-list-item-action>
+        </v-list-item>
+      </v-flex>
+    </template>
+    <template slot="content">
+      <v-flex id="commentDrawerContent" class="drawerContent flex-grow-1 overflow-auto border-box-sizing">
+        <div
+          v-if="this.comments && this.comments.length"
+          class="TaskCommentContent">
           <div
-            v-if="this.comments && this.comments.length"
-            class="TaskCommentContent">
-            <div
-              v-for="(item, i) in comments"
-              :key="i"
-              class="pe-0 ps-0 TaskCommentItem">
-              <task-comments
-                :task="task"
-                :comment="item"
-                :comments="comments"
-                :last-comment="commentId"
-                :show-new-comment-editor="showNewCommentEditor"
-                @confirmDialogOpened="$emit('confirmDialogOpened')"
-                @confirmDialogClosed="$emit('confirmDialogClosed')" />
-            </div>
+            v-for="(item, i) in comments"
+            :key="i"
+            class="pe-0 ps-0 TaskCommentItem">
+            <task-comments
+              :task="task"
+              :comment="item"
+              :comments="comments"
+              :last-comment="commentId"
+              :show-new-comment-editor="showNewCommentEditor"
+              @confirmDialogOpened="$emit('confirmDialogOpened')"
+              @confirmDialogClosed="$emit('confirmDialogClosed')" />
           </div>
-          <div v-else-if="drawer">
-            <div class="editorContent commentEditorContainer newCommentEditor">
-              <task-comment-editor
-                ref="commentEditor"
-                :max-length="MESSAGE_MAX_LENGTH"
-                :placeholder="$t('task.placeholder').replace('{0}', MESSAGE_MAX_LENGTH)"
-                :task="task"
-                :show-comment-editor="true"
-                :id="'commentContent-editor'"
-                class="subComment subCommentEditor"
-                @addNewComment="addTaskComment($event)" />
-            </div>
+        </div>
+        <div v-else-if="drawer">
+          <div class="editorContent commentEditorContainer newCommentEditor">
+            <task-comment-editor
+              ref="commentEditor"
+              :max-length="MESSAGE_MAX_LENGTH"
+              :placeholder="$t('task.placeholder').replace('{0}', MESSAGE_MAX_LENGTH)"
+              :task="task"
+              :show-comment-editor="true"
+              :id="'commentContent-editor'"
+              class="subComment subCommentEditor"
+              @addNewComment="addTaskComment($event)" />
           </div>
-        </v-flex>
-      </template>
-    </exo-drawer>
-  </v-app>
+        </div>
+      </v-flex>
+    </template>
+  </exo-drawer>
 </template>
 <script>
 export default {

--- a/webapps/src/main/webapp/vue-app/tasks-management/components/Project/ProjectCard.vue
+++ b/webapps/src/main/webapp/vue-app/tasks-management/components/Project/ProjectCard.vue
@@ -15,7 +15,7 @@
   Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 -->
 <template>
-  <v-app id="projectCard">
+  <div id="projectCard">
     <v-flex :class="flipCard && 'taskCardFlip taskCardFlipped' || 'taskCardFlip'">
       <div class="taskCardFront py-3 px-2">
         <project-card-front
@@ -32,7 +32,7 @@
           @flip="flipCard = false; flip()" />
       </div>
     </v-flex>
-  </v-app>
+  </div>
 </template>
 <script>
 export default {

--- a/webapps/src/main/webapp/vue-app/tasks-management/components/Project/ProjectCardList.vue
+++ b/webapps/src/main/webapp/vue-app/tasks-management/components/Project/ProjectCardList.vue
@@ -20,7 +20,7 @@
 
 -->
 <template>
-  <v-app id="ProjectCardList" class="tasksListContainer">
+  <div id="ProjectCardList" class="tasksListContainer">
     <div
       v-if="showPlaceholder"
       class="noTasksProject">
@@ -71,7 +71,7 @@
         </v-item-group>
       </v-card>
     </div>
-  </v-app>
+  </div>
 </template>
 <script>
 export default {

--- a/webapps/src/main/webapp/vue-app/tasks-management/components/Project/ProjectDashboard.vue
+++ b/webapps/src/main/webapp/vue-app/tasks-management/components/Project/ProjectDashboard.vue
@@ -15,7 +15,7 @@
   Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 -->
 <template>
-  <v-app
+  <div
     id="projectListApplication"
     class="projectAndTasksContainer pa-4 pb-2 transparent"
     flat>
@@ -38,7 +38,7 @@
       <tasks-view-dashboard :project="project" />
     </div>
     <project-manager-drawer />
-  </v-app>
+  </div>
 </template>
 <script>
 export default {

--- a/webapps/src/main/webapp/vue-app/tasks-management/components/Project/ProjectListToolbar.vue
+++ b/webapps/src/main/webapp/vue-app/tasks-management/components/Project/ProjectListToolbar.vue
@@ -15,7 +15,7 @@
   Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 -->
 <template>
-  <v-app id="projectBoardToolbar">
+  <div id="projectBoardToolbar">
     <v-toolbar
       id="ProjectListToolbar"
       :class="showMobileTaskFilter && 'toolbarLarge'"
@@ -75,7 +75,7 @@
         </select>
       </v-scale-transition>
     </v-toolbar>
-  </v-app>
+  </div>
 </template>
 <script>
 export default {

--- a/webapps/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TaskViewCard.vue
+++ b/webapps/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TaskViewCard.vue
@@ -15,7 +15,7 @@
   Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 -->
 <template>
-  <v-app
+  <div
     id="taskCardItem"
     class="taskBoardCardItem"
     :class="removeCompletedTask && 'completedTask' || ''">
@@ -118,7 +118,7 @@
         </div>
       </v-card>
     </v-hover>
-  </v-app>
+  </div>
 </template>
 <script>
 export default {

--- a/webapps/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TasksViewDashboard.vue
+++ b/webapps/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TasksViewDashboard.vue
@@ -15,7 +15,7 @@
   Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 -->
 <template>
-  <v-app
+  <div
     :id="'projectTask-'+project.id"
     :class="taskViewTabName === 'board' && !filterProjectActive && 'projectTaskBoardContainer'"
     class="projectTasksDashboard">
@@ -206,7 +206,7 @@
     <tasks-unscheduled-drawer 
       :project="project"
       :show-completed-tasks="showCompletedTasks" />
-  </v-app>
+  </div>
 </template>
 <script>
 export default {

--- a/webapps/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TasksViewList.vue
+++ b/webapps/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TasksViewList.vue
@@ -15,9 +15,9 @@
   Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 -->
 <template>
-  <v-app class="tasksList">
+  <div class="tasksList">
     <v-card
-      class="tasksView tasksListItem tasksViewList app-background-color pt-5"
+      class="tasksView tasksListItem tasksViewList pt-5"
       flat>
       <v-item-group>
         <div class="ma-0 border-box-sizing">
@@ -46,7 +46,7 @@
         </div>
       </v-item-group>
     </v-card>
-  </v-app>
+  </div>
 </template>
 <script>
 export default {

--- a/webapps/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TasksViewToolbar.vue
+++ b/webapps/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TasksViewToolbar.vue
@@ -15,11 +15,11 @@
   Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 -->
 <template>
-  <v-app>
+  <div>
     <v-toolbar
       id="TasksDashboardToolbar"
       flat
-      class="tasksToolbar app-background-color">
+      class="tasksToolbar">
       <div class="taskDisplay">
         <v-tabs
           class="projectTasksViewTabs">
@@ -78,7 +78,7 @@
       @filter-num-changed="filterNumChanged"
       @filter-task="filterTasks"
       @reset-filter-task="resetFilterTask" />
-  </v-app>
+  </div>
 </template>
 <script>
 export default {

--- a/webapps/src/main/webapp/vue-app/tasks-management/components/TasksManagement.vue
+++ b/webapps/src/main/webapp/vue-app/tasks-management/components/TasksManagement.vue
@@ -16,26 +16,31 @@
 -->
 <template>
   <v-app id="TasksManagementPortlet">
-    <v-tabs 
-      v-if="showTabs"
-      v-model="tab"
-      slider-size="4"
-      class="tasksMenuParent card-border-radius app-background-color overflow-hidden white">
-      <v-tab href="#tab-2" @click="getMyProjects()">
-        {{ $t('label.projects') }}
-      </v-tab>
-      <v-tab href="#tab-1" @click="getMyTasks()">
-        {{ $t('label.tasks.header') }}
-      </v-tab>
-    </v-tabs>
-    <v-tabs-items v-model="tab" class="card-border-radius app-background-color">
-      <v-tab-item value="tab-1">
-        <tasks-dashboard />
-      </v-tab-item>
-      <v-tab-item value="tab-2">
-        <project-dashboard :space-name="spaceName" :display-details="displayDetails" />
-      </v-tab-item>
-    </v-tabs-items>
+    <div class="application-body">
+      <v-tabs
+        v-if="showTabs"
+        v-model="tab"
+        slider-size="4"
+        class="tasksMenuParent application-background-color application-border application-border-radius-top">
+        <v-tab href="#tab-2" @click="getMyProjects()">
+          {{ $t('label.projects') }}
+        </v-tab>
+        <v-tab href="#tab-1" @click="getMyTasks()">
+          {{ $t('label.tasks.header') }}
+        </v-tab>
+      </v-tabs>
+      <v-tabs-items
+        v-model="tab"
+        :class="showTabs && 'application-border-radius-bottom' || 'application-border-radius'"
+        class="application-background-color application-border">
+        <v-tab-item value="tab-1">
+          <tasks-dashboard />
+        </v-tab-item>
+        <v-tab-item value="tab-2">
+          <project-dashboard :space-name="spaceName" :display-details="displayDetails" />
+        </v-tab-item>
+      </v-tabs-items>
+    </div>
     <add-project-drawer
       ref="addProjectDrawer" />
 

--- a/webapps/src/main/webapp/vue-app/tasks-management/components/tasks/TaskCard.vue
+++ b/webapps/src/main/webapp/vue-app/tasks-management/components/tasks/TaskCard.vue
@@ -15,7 +15,7 @@
   Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 -->
 <template>
-  <v-app
+  <div
     id="taskCardItem"
     :class="removeCompletedTask && 'completedTask' || ''">
     <v-card
@@ -113,7 +113,7 @@
         </div>
       </div>
     </v-card>
-  </v-app>
+  </div>
 </template>
 <script>
 export default {

--- a/webapps/src/main/webapp/vue-app/tasks-management/components/tasks/TasksCardsList.vue
+++ b/webapps/src/main/webapp/vue-app/tasks-management/components/tasks/TasksCardsList.vue
@@ -15,7 +15,7 @@
   Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 -->
 <template>
-  <v-app id="TasksCardList" class="tasksCardsContainer">
+  <div id="TasksCardList" class="tasksCardsContainer">
     <v-card flat>
       <v-item-group class="pa-4">
         <v-container class="pa-0">
@@ -37,7 +37,7 @@
         </v-container>
       </v-item-group>
     </v-card>
-  </v-app>
+  </div>
 </template>
 <script>
 export default {

--- a/webapps/src/main/webapp/vue-app/tasks-management/components/tasks/TasksDashboard.vue
+++ b/webapps/src/main/webapp/vue-app/tasks-management/components/tasks/TasksDashboard.vue
@@ -20,7 +20,7 @@
 
 -->
 <template>
-  <v-app
+  <div
     id="tasksListApplication"
     class="projectAndTasksContainer transparent pa-4"
     flat>
@@ -147,7 +147,7 @@
         {{ $t('spacesList.button.showMore') }}
       </v-btn>
     </v-row>
-  </v-app>
+  </div>
 </template>
 <script>
 export default {

--- a/webapps/src/main/webapp/vue-app/tasks-management/components/tasks/TasksList.vue
+++ b/webapps/src/main/webapp/vue-app/tasks-management/components/tasks/TasksList.vue
@@ -15,7 +15,7 @@
   Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 -->
 <template>
-  <v-app class="tasksList pt-5">
+  <div class="tasksList pt-5">
     <div
       v-for="task in tasks"
       :key="task.id"
@@ -24,7 +24,7 @@
         :task="task"
         :show-completed-tasks="showCompletedTasks" />
     </div>
-  </v-app>
+  </div>
 </template>
 <script>
 export default {

--- a/webapps/src/main/webapp/vue-app/tasks-management/components/tasks/TasksListToolbar.vue
+++ b/webapps/src/main/webapp/vue-app/tasks-management/components/tasks/TasksListToolbar.vue
@@ -15,7 +15,7 @@
   Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 -->
 <template>
-  <v-app id="TasksToolbar">
+  <div id="TasksToolbar">
     <v-toolbar
       id="TasksListToolbar"
       :class="showMobileTaskFilter && 'toolbarLarge'"
@@ -93,7 +93,7 @@
       @filter-task="filterTasks"
       @reset-filter-task="resetFilterTask"
       @filter-task-query="filterTaskquery" />
-  </v-app>
+  </div>
 </template>
 <script>
 export default {

--- a/webapps/src/main/webapp/vue-app/tasks/components/TasksApp.vue
+++ b/webapps/src/main/webapp/vue-app/tasks/components/TasksApp.vue
@@ -16,7 +16,9 @@
 -->
 <template>
   <v-app>
-    <widget-wrapper :loading="loadingTasks">
+    <widget-wrapper
+      :loading="loadingTasks"
+      extra-class="application-body">
       <template #title>
         <a 
           class="widget-text-header text-truncate" 
@@ -88,7 +90,6 @@
       </div>
       <v-card
         v-else
-        class="app-background-color"
         min-height="188"
         flat>
         <task-empty-row v-if="displayPlaceholder" @open-task-drawer="openTaskDrawer" />


### PR DESCRIPTION
This change will apply **application-body** class to the main body of applications to make sure to apply layout specific CSS styles, such as disabling default Vuetify White Background applied on v-card. At the same time, for Top Toolbar applications, this will disable branding styling to avoid having border radius and other styles applied on small buttons added in Top bar as applications.