### PR TITLE
fix: Fix Tasks Card Style - MEED-7224 - Meeds-io/meeds#2275

### DIFF
--- a/webapps/src/main/webapp/skin/css/tasks.less
+++ b/webapps/src/main/webapp/skin/css/tasks.less
@@ -530,9 +530,6 @@
 .tasksMenuParent {
   margin-bottom: 10px;
 }
-.VuetifyApp .v-sheet.v-card:not(.v-sheet--outlined) {
-  box-shadow: none!important;
-}
 .taskFilter.v-card.v-sheet.theme--light{
   box-shadow: none!important;
   header.v-sheet.theme--light.v-toolbar {

--- a/webapps/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskAssignment.vue
+++ b/webapps/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskAssignment.vue
@@ -53,7 +53,7 @@
           </a>
         </div>
       </template>
-      <v-card class="pb-4">
+      <v-card class="pb-4" flat>
         <v-card-text class="assignTaskMenu pb-0 d-flex justify-space-between">
           <span>{{ $t('label.assignTo') }} :</span>
           <a class="ms-4" @click="assignToMe()">

--- a/webapps/src/main/webapp/vue-app/taskSearch/components/TaskSearchCard.vue
+++ b/webapps/src/main/webapp/vue-app/taskSearch/components/TaskSearchCard.vue
@@ -17,8 +17,8 @@
 <template>
   <v-card 
     class="d-flex flex-column border-radius box-shadow" 
-    flat
-    min-height="227">
+    min-height="227"
+    flat>
     <a
       v-sanitized-html="taskTitle"
       :title="taskTitleText"

--- a/webapps/src/main/webapp/vue-app/tasks-management/components/tasks/TasksFilterDrawer.vue
+++ b/webapps/src/main/webapp/vue-app/tasks-management/components/tasks/TasksFilterDrawer.vue
@@ -26,7 +26,7 @@
     <template slot="content">
       <div class="VuetifyApp">
         <template>
-          <v-card class="taskFilter">
+          <v-card class="taskFilter" flat>
             <v-toolbar dense>
               <v-tabs
                 v-model="tab">
@@ -38,7 +38,7 @@
 
             <v-tabs-items v-model="tab">
               <v-tab-item v-if="!project">
-                <v-card>
+                <v-card flat>
                   <tasks-group-drawer
                     ref="filterGroupTasksDrawer"
                     v-model="groupBy" />
@@ -49,7 +49,7 @@
               </v-tab-item>
 
               <v-tab-item v-if="project">
-                <v-card>
+                <v-card flat>
                   <tasks-group-project-drawer
                     ref="filterGroupTasksDrawer"
                     v-model="groupBy"
@@ -63,7 +63,7 @@
               </v-tab-item>
 
               <v-tab-item>
-                <v-card>
+                <v-card flat>
                   <form ref="form1" class="mt-4">
                     <v-label for="name">
                       <span class="font-weight-bold body-2">{{ $t('filter.task.contains') }}</span>
@@ -156,7 +156,7 @@
               </v-tab-item>
 
               <v-tab-item>
-                <v-card>
+                <v-card flat>
                   <tasks-labels-drawer
                     ref="filterLabelsTasksDrawer"
                     :project-id="projectId"


### PR DESCRIPTION
Prior to this change, a generic Vuetify CSS is overridden in Tasks. This change will delete this override and adjust styling using Vuetify attributes instead.

Resolves https://github.com/Meeds-io/meeds/issues/2275