### PR TITLE
fix: A project can be cloned by a user which have not edit rights - EXO-73660

### DIFF
--- a/services/src/main/java/org/exoplatform/task/rest/ProjectRestService.java
+++ b/services/src/main/java/org/exoplatform/task/rest/ProjectRestService.java
@@ -684,7 +684,7 @@ public class ProjectRestService implements ResourceContainer {
           @ApiResponse(responseCode = "404", description = "Resource not found") })
   public Response cloneProject(@Parameter(description = "Project object to clone", required = true) ProjectDto projectDto) {
     try {
-      ProjectDto currentProject = projectDto;
+      ProjectDto currentProject = projectService.getProject(projectDto.getId());
       if (!currentProject.canEdit(ConversationState.getCurrent().getIdentity())) {
         return Response.status(Response.Status.UNAUTHORIZED).build();
       }

--- a/services/src/test/java/org/exoplatform/task/rest/TestProjectRestService.java
+++ b/services/src/test/java/org/exoplatform/task/rest/TestProjectRestService.java
@@ -605,6 +605,7 @@ public class TestProjectRestService {
     projectCloned.setManager(manager);
 
     when(projectService.cloneProject(projectDto.getId(), true)).thenReturn(projectCloned);
+    when(projectService.getProject(projectDto.getId())).thenReturn(projectDto);
 
     Response response1 = projectRestService.cloneProject(projectDto);
     assertEquals(Response.Status.OK.getStatusCode(), response1.getStatus());

--- a/services/src/test/java/org/exoplatform/task/storage/CommentStorageTest.java
+++ b/services/src/test/java/org/exoplatform/task/storage/CommentStorageTest.java
@@ -21,6 +21,8 @@ package org.exoplatform.task.storage;
 import java.util.Date;
 import java.util.Set;
 
+import org.exoplatform.task.dao.CommentHandler;
+import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -46,7 +48,8 @@ public class CommentStorageTest extends AbstractTest {
 
   private CommentStorage      commentStorage;
 
-  private TaskHandler         taskDAO;
+  private TaskHandler    taskDAO;
+  private CommentHandler commentDAO;
 
   @Before
   public void init() {
@@ -57,8 +60,15 @@ public class CommentStorageTest extends AbstractTest {
     commentStorage = container.getComponentInstanceOfType(CommentStorage.class);
     DAOHandler daoHandler = container.getComponentInstanceOfType(DAOHandler.class);
     taskDAO = daoHandler.getTaskHandler();
+    commentDAO = daoHandler.getCommentHandler();
   }
 
+  @After
+  public void cleanData() {
+    endRequestLifecycle();
+    commentDAO.deleteAll();
+    taskDAO.deleteAll();
+  }
   @Test
   public void testMentionedUsers() throws EntityNotFoundException {
     TaskDto task = newDefaultSimpleTask();


### PR DESCRIPTION
Before this fix, a project can be cloned by a user which have not edit rights on this This is due to the fact that edit permissions are checked on the rest dto, so on user controlled data. The fix modifies the behaviour by getting project from projectService and so getting correct permissions, and then check edit right on the real project.

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
