### PR TITLE
fix: fix background color when moving task - MEED-7399 - Meeds-io/MIPs#156

### DIFF
--- a/webapps/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TasksViewBoard.vue
+++ b/webapps/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TasksViewBoard.vue
@@ -119,7 +119,6 @@ export default {
     dragStatus(val) {
       if (!val){
         this.$emit('move-status',this.indexStatusTo);
-        Array.from(document.getElementsByClassName('draggable-palceholder')).forEach(element => element.style.backgroundColor= '#FFFFFF');
       }},
   },
   created(){
@@ -133,8 +132,6 @@ export default {
     },
     checkMoveStatus(evt){
       if (evt){
-        Array.from(document.getElementsByClassName('draggable-palceholder')).forEach(element => element.style.backgroundColor= '#FFFFFF');
-        Array.from(evt.to.parentElement.getElementsByClassName('draggable-palceholder')).forEach(element => element.style.backgroundColor= '#f2f2f2');
         this.indexStatusFrom = evt.draggedContext.index;
         this.indexStatusTo = evt.draggedContext.futureIndex;
       }

--- a/webapps/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TasksViewBoardColumn.vue
+++ b/webapps/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TasksViewBoardColumn.vue
@@ -132,7 +132,6 @@ export default {
       if (this.task && this.newStatus && this.task.status.name !== this.newStatus) {
         this.$emit('updateTaskStatus', this.task,this.newStatus);
       }
-      Array.from(document.getElementsByClassName('draggable-palceholder')).forEach(element => element.style.backgroundColor= '#FFFFFF');
       this.drag = false;
     },
     cancelDrag() {
@@ -149,8 +148,6 @@ export default {
     },
     checkMove(evt){
       if (evt){
-        Array.from(document.getElementsByClassName('draggable-palceholder')).forEach(element => element.style.backgroundColor= '#FFFFFF');
-        Array.from(evt.to.parentElement.getElementsByClassName('draggable-palceholder')).forEach(element => element.style.backgroundColor= '#f2f2f2');
         this.task = evt.draggedContext.element.task;
         this.newStatus = evt.relatedContext.component.$parent.status.name;
       }

--- a/webapps/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TasksViewListColumn.vue
+++ b/webapps/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TasksViewListColumn.vue
@@ -86,7 +86,6 @@ export default {
     drag(val) {
       if (!val&&this.task&&this.newStatus&&this.task.status.id.toString() !== this.newStatus){
         this.$emit('updateTaskStatus', this.task,this.newStatus);
-        Array.from(document.getElementsByClassName('draggable-palceholder')).forEach(element => element.style.backgroundColor= '#FFFFFF');
       }
     },
   },
@@ -100,8 +99,6 @@ export default {
     },
     checkMove(evt){
       if (evt){
-        Array.from(document.getElementsByClassName('draggable-palceholder')).forEach(element => element.style.backgroundColor= '#FFFFFF');
-        Array.from(evt.to.parentElement.getElementsByClassName('draggable-palceholder')).forEach(element => element.style.backgroundColor= '#f2f2f2');
         this.task = evt.draggedContext.element.task;
         this.newStatus = evt.to.parentElement.id;
       }


### PR DESCRIPTION
Prior to this change, when drag & drop a Task, a fixed background color is applied on Task columns. This change deletes the background color change to ensure to use the application background all time.