### PR TITLE
fix: Display mention user ko if username has email format - EXO-72863 - Meeds-io/meeds#2342.

### DIFF
--- a/services/src/main/java/org/exoplatform/task/util/CommentUtil.java
+++ b/services/src/main/java/org/exoplatform/task/util/CommentUtil.java
@@ -75,7 +75,7 @@ public final class CommentUtil {
           next += "</a>";
         }
       } else if (next.contains("@")) {
-        String username = next.split("@")[1];
+        String username = next.replace(next.split("@")[0].concat("@"),"");
         User user = userService.loadUser(username);
         if (user != null && !"guest".equals(user.getUsername())) {
           next = next.split("@")[0] + "<a href=\"" + CommonsUtils.getCurrentDomain() + user.getUrl() + "\">"


### PR DESCRIPTION
Before this change, when create userX having username user@user.com then add userX to spaceX which has task app and create task and mention userX in comment then save, userX's username displayed isn't clickable and content isn't expected. After this change, userX's username is displayed and clickable.