### PR TITLE
Fix: Task status labels are not translated on the project details - EXO-73978

### DIFF
--- a/webapps/src/main/webapp/vue-app/tasks-management/components/Project/ProjectCardReverse.vue
+++ b/webapps/src/main/webapp/vue-app/tasks-management/components/Project/ProjectCardReverse.vue
@@ -125,7 +125,9 @@ export default {
       this.$projectService.getProjectStats(project.id).then(data => {
         this.totalLeftTasks = data.totalNumberTasks || 0;
         let otherTasksCount = 0;
-        this.statistics = data.statusStats.sort((a, b) => b.value - a.value);        
+        this.statistics = data.statusStats.sort((a, b) => b.value - a.value).map(item => {
+          return { ...item, name: this.getI18N(item.name) };
+        });        
         if (data.statusStats.length>5){
           otherTasksCount= data.statusStats.length-5;
           this.statistics.splice(5,otherTasksCount,{ 'name': this.$t('Others'), 'value': otherTasksCount });
@@ -138,7 +140,12 @@ export default {
           },200);
         }
       });
-    }
+    },
+    getI18N(label){
+      const fieldLabelI18NKey = `tasks.status.${label}`;
+      const fieldLabelI18NValue = this.$t(fieldLabelI18NKey);
+      return  fieldLabelI18NValue === fieldLabelI18NKey ? label : fieldLabelI18NValue;
+    } 
   }
 };
 </script>


### PR DESCRIPTION
 Prior to this fix, task status labels are not translated in project reverse card, this commit repalbce the translated lebel if exists
