### PR TITLE
fix: plan view is ko in language different from EN & FR - EXO-72317 -Meeds-io/meeds#2140.

### DIFF
--- a/webapps/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskProject.vue
+++ b/webapps/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskProject.vue
@@ -131,12 +131,8 @@ export default {
     document.addEventListener('loadProjectName', event => {
       if (event && event.detail) {
         const task = event.detail;
-        if (task.id!=null && task.status && task.status.project) {
+        if (task.status && task.status.project) {
           this.projectModel = this.task.status.project;
-          this.projectLabel = this.$t('label.tapProject.name');
-        } else if (task.id==null && task.status && task.status.project){
-          this.projectModel = this.task.status.project;
-          this.projectLabel = this.$t('label.tapProject.name');
         } else {
           this.projectModel = null;
           this.projectLabel = this.$t('label.noProject');


### PR DESCRIPTION
Before this change, when set plf langue to langue except english or french then open tasks project and create tasks with start and end date then open plan view, nothing displayed in plan view and error in browser console. After this change, plan view is available as it is the case for French & English.