### PR TITLE
fix: Bad display after deleting a task - EXO-46811 -Meeds-io/meeds#2497.

### DIFF
--- a/webapps/src/main/webapp/vue-app/taskDrawer/components/TaskDrawer.vue
+++ b/webapps/src/main/webapp/vue-app/taskDrawer/components/TaskDrawer.vue
@@ -782,6 +782,7 @@ export default {
         document.dispatchEvent(new CustomEvent('deleteTask', {
           detail: this.task.id
         }));
+        this.$refs.addTaskDrawer.close();
       }).catch(e => {
         console.error('Error when deleting task', e);
         this.$root.$emit('show-alert', {


### PR DESCRIPTION
Before this change, when creates a task in Task's project and deletes it, the deleted task drawer is still displayed. To resolve this problem, add the closure of this drawer after confirmation of deletion. After this change, The drawer is automatically closed.