### PR TITLE
feat: Review Portlet Instances Default Permissions - MEED-7668 - Meeds-io/meeds#2528

### DIFF
--- a/services/src/main/resources/portlet-instances.json
+++ b/services/src/main/resources/portlet-instances.json
@@ -34,7 +34,8 @@
         
       ],
       "permissions":[
-        "Everyone"
+        "*:/platform/administrators",
+        "*:/platform/web-contributors"
       ],
       "system":true
     }


### PR DESCRIPTION
This change will hide `Tasks Widget` portlet instance for Space Managers when editing their layout to be visible for administrators and content managers only.