### PR TITLE
fix: Task comments are not displayed when opening task with the task gadget on My Workplace homepage - EXO-75152

### DIFF
--- a/webapps/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/webapps/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -106,6 +106,9 @@
       <module>taskDrawer</module>
     </depends>
     <depends>
+      <module>ExtendedDomPurify</module>
+    </depends>
+    <depends>
       <module>eXoVueI18n</module>
     </depends>
     <depends>


### PR DESCRIPTION
Before this fix, task comments are not displayed due to a missing js dependencies in task gadget : ExtendedDomPurify This commit add the js module in dependencies of this application

Resolved meeds-io/meeds#2544

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
