### PR TITLE
fix: Update default charset and collation for mysql - EXO-75202

### DIFF
--- a/services/src/main/resources/db/changelog/task.db.changelog-1.0.0.xml
+++ b/services/src/main/resources/db/changelog/task.db.changelog-1.0.0.xml
@@ -32,13 +32,13 @@
       <column name="PROJECT_ID" type="BIGINT" autoIncrement="${autoIncrement}" startWith="1">
         <constraints nullable="false" primaryKey="true" primaryKeyName="PK_TASK_PROJECTS" />
       </column>
-      <column name="NAME" type="NVARCHAR(50)">
+      <column name="NAME" type="VARCHAR(50)">
         <constraints nullable="false"/>
       </column>
-      <column name="DESCRIPTION" type="NVARCHAR(2000)">
+      <column name="DESCRIPTION" type="VARCHAR(2000)">
         <constraints nullable="true"/>
       </column>
-      <column name="COLOR" type="NVARCHAR(100)">
+      <column name="COLOR" type="VARCHAR(100)">
         <constraints nullable="true"/>
       </column>
       <column name="CALENDAR_INTEGRATED" type="BOOLEAN" defaultValueBoolean="false">
@@ -52,7 +52,7 @@
       </column>
     </createTable>
     <modifySql dbms="mysql">
-      <append value=" ENGINE=INNODB CHARSET=UTF8 COLLATE utf8_general_ci"/>
+      <append value=" ENGINE=INNODB CHARSET=UTF8MB4 COLLATE utf8mb4_0900_ai_ci"/>
     </modifySql>
   </changeSet>
   <changeSet author="task" id="1.0.0-2" dbms="oracle,postgresql">
@@ -61,41 +61,47 @@
 
   <!-- Definition of TASK_PROJECT_MANAGER table -->
   <changeSet author="task" id="1.0.0-3">
+    <validCheckSum>9:79fad38f6918e5d072fa979fa058a7e2</validCheckSum>
+    <validCheckSum>9:e24c38de06b2acbdafe59a4df714429c</validCheckSum>
     <createTable tableName="TASK_PROJECT_MANAGERS">
       <column name="PROJECT_ID" type="BIGINT">
         <constraints foreignKeyName="FK_TASK_PRJ_MGR_TASK_PRJ_01" references="TASK_PROJECTS(PROJECT_ID)" nullable="false"/>
       </column>
-      <column name="MANAGER" type="NVARCHAR(50)">
+      <column name="MANAGER" type="VARCHAR(50)">
         <constraints nullable="false"/>
       </column>
     </createTable>
     <modifySql dbms="mysql">
-      <append value=" ENGINE=INNODB CHARSET=UTF8 COLLATE utf8_general_ci"/>
+      <append value=" ENGINE=INNODB CHARSET=UTF8MB4 COLLATE utf8mb4_0900_ai_ci"/>
     </modifySql>
   </changeSet>
 
   <!-- Definition of TASK_PROJECT_PARTICIPATOR table -->
   <changeSet author="task" id="1.0.0-4">
+    <validCheckSum>9:c62322e6a2fe85fed13cf7f12bdc506c</validCheckSum>
+    <validCheckSum>9:577cdb23fdd44c84d74beab651ad4408</validCheckSum>
     <createTable tableName="TASK_PROJECT_PARTICIPATORS">
       <column name="PROJECT_ID" type="BIGINT">
         <constraints foreignKeyName="FK_TASK_PRJ_PTOR_TASK_PRJ_01" references="TASK_PROJECTS(PROJECT_ID)" nullable="false"/>
       </column>
-      <column name="PARTICIPATOR" type="NVARCHAR(50)">
+      <column name="PARTICIPATOR" type="VARCHAR(50)">
         <constraints nullable="false"/>
       </column>
     </createTable>
     <modifySql dbms="mysql">
-      <append value=" ENGINE=INNODB CHARSET=UTF8 COLLATE utf8_general_ci"/>
+      <append value=" ENGINE=INNODB CHARSET=UTF8MB4 COLLATE utf8mb4_0900_ai_ci"/>
     </modifySql>
   </changeSet>
 
   <!-- Definition of TASK_STATUS table -->
   <changeSet author="task" id="1.0.0-5">
+    <validCheckSum>9:e214f77abcbad266da9615906eb45c00</validCheckSum>
+    <validCheckSum>9:8ab9e83e4415e010554f5d4bfa01c273</validCheckSum>
     <createTable tableName="TASK_STATUS">
       <column name="STATUS_ID" type="BIGINT" autoIncrement="${autoIncrement}" startWith="1">
         <constraints nullable="false" primaryKey="true" primaryKeyName="PK_TASK_STATUS"/>
       </column>
-      <column name="NAME" type="NVARCHAR(50)">
+      <column name="NAME" type="VARCHAR(50)">
         <constraints nullable="false"/>
       </column>
       <column name="RANK" type="INTEGER">
@@ -106,7 +112,7 @@
       </column>
     </createTable>
     <modifySql dbms="mysql">
-      <append value=" ENGINE=INNODB CHARSET=UTF8 COLLATE utf8_general_ci"/>
+      <append value=" ENGINE=INNODB CHARSET=UTF8MB4 COLLATE utf8mb4_0900_ai_ci"/>
     </modifySql>
   </changeSet>
   <changeSet author="task" id="1.0.0-6" dbms="oracle,postgresql">
@@ -120,25 +126,25 @@
       <column name="TASK_ID" type="BIGINT" autoIncrement="${autoIncrement}" startWith="1">
         <constraints primaryKey="true" primaryKeyName="PK_TASK_TASKS" nullable="false"/>
       </column>
-      <column name="TITLE" type="NVARCHAR(250)">
+      <column name="TITLE" type="VARCHAR(250)">
         <constraints nullable="false"/>
       </column>
-      <column name="DESCRIPTION" type="NVARCHAR(2000)">
+      <column name="DESCRIPTION" type="VARCHAR(2000)">
         <constraints nullable="true"/>
       </column>
       <column name="PRIORITY" type="INTEGER" defaultValue="0">
         <constraints nullable="true"/>
       </column>
-      <column name="CONTEXT" type="NVARCHAR(255)">
+      <column name="CONTEXT" type="VARCHAR(255)">
         <constraints nullable="true"/>
       </column>
-      <column name="ASSIGNEE" type="NVARCHAR(50)">
+      <column name="ASSIGNEE" type="VARCHAR(50)">
         <constraints nullable="true"/>
       </column>
       <column name="STATUS_ID" type="BIGINT">
         <constraints foreignKeyName="FK_TASK_TASKS_TASK_STATUS_01" references="TASK_STATUS(STATUS_ID)" nullable="true"/>
       </column>
-      <column name="CREATED_BY" type="NVARCHAR(50)">
+      <column name="CREATED_BY" type="VARCHAR(50)">
         <constraints nullable="true"/>
       </column>
       <column name="CREATED_TIME" type="TIMESTAMP">
@@ -161,7 +167,7 @@
       </column>
     </createTable>
     <modifySql dbms="mysql">
-      <append value=" ENGINE=INNODB CHARSET=UTF8 COLLATE utf8_general_ci"/>
+      <append value=" ENGINE=INNODB CHARSET=UTF8MB4 COLLATE utf8mb4_0900_ai_ci"/>
     </modifySql>
   </changeSet>
   <changeSet author="task" id="1.0.0-8" dbms="oracle,postgresql">
@@ -170,44 +176,50 @@
 
   <!-- Definition of TASK_TASK_COWORKER table -->
   <changeSet author="task" id="1.0.0-9">
+    <validCheckSum>9:f5bf07fc8d74e812705ff34e0d7925be</validCheckSum>
+    <validCheckSum>9:713428ac184898a267d5dfc1a4b6ffb6</validCheckSum>
     <createTable tableName="TASK_TASK_COWORKERS">
       <column name="TASK_ID" type="BIGINT">
         <constraints foreignKeyName="FK_TK_TK_COWKR_TK_TK_01" references="TASK_TASKS(TASK_ID)" nullable="false"/>
       </column>
-      <column name="COWORKER" type="NVARCHAR(50)">
+      <column name="COWORKER" type="VARCHAR(50)">
         <constraints nullable="false"/>
       </column>
     </createTable>
     <modifySql dbms="mysql">
-      <append value=" ENGINE=INNODB CHARSET=UTF8 COLLATE utf8_general_ci"/>
+      <append value=" ENGINE=INNODB CHARSET=UTF8MB4 COLLATE utf8mb4_0900_ai_ci"/>
     </modifySql>
   </changeSet>
 
   <!-- Definition of TASK_TAGS table -->
   <changeSet author="task" id="1.0.0-10">
+    <validCheckSum>9:92eedb14c7469f037c93becb8cdcd290</validCheckSum>
+    <validCheckSum>9:6d566cd50824a9b2329a043a9a3ecc4b</validCheckSum>
     <createTable tableName="TASK_TAGS">
       <column name="TASK_ID" type="BIGINT">
         <constraints foreignKeyName="FK_TASK_TAGS_TASK_TASKS_01" references="TASK_TASKS(TASK_ID)" nullable="false"/>
       </column>
-      <column name="TAG" type="NVARCHAR(50)">
+      <column name="TAG" type="VARCHAR(50)">
         <constraints nullable="false"/>
       </column>
     </createTable>
     <modifySql dbms="mysql">
-      <append value=" ENGINE=INNODB CHARSET=UTF8 COLLATE utf8_general_ci"/>
+      <append value=" ENGINE=INNODB CHARSET=UTF8MB4 COLLATE utf8mb4_0900_ai_ci"/>
     </modifySql>
   </changeSet>
 
   <!-- Definition of TASK_COMMENTS table -->
   <changeSet author="task" id="1.0.0-11">
+    <validCheckSum>9:c9a96c52f12cdaa0b556d7b4914b2218</validCheckSum>
+    <validCheckSum>9:88d97e6482fdc173d9bfb0db3725403f</validCheckSum>
     <createTable tableName="TASK_COMMENTS">
       <column name="COMMENT_ID" type="BIGINT" autoIncrement="${autoIncrement}" startWith="1">
         <constraints primaryKey="true" primaryKeyName="PK_TASK_COMMENTS" nullable="false"/>
       </column>
-      <column name="AUTHOR" type="NVARCHAR(100)">
+      <column name="AUTHOR" type="VARCHAR(100)">
         <constraints nullable="false"/>
       </column>
-      <column name="CMT" type="NVARCHAR(2000)">
+      <column name="CMT" type="VARCHAR(2000)">
         <constraints nullable="false"/>
       </column>
       <column name="CREATED_TIME" type="TIMESTAMP">
@@ -218,7 +230,7 @@
       </column>
     </createTable>
     <modifySql dbms="mysql">
-      <append value=" ENGINE=INNODB CHARSET=UTF8 COLLATE utf8_general_ci"/>
+      <append value=" ENGINE=INNODB CHARSET=UTF8MB4 COLLATE utf8mb4_0900_ai_ci"/>
     </modifySql>
   </changeSet>
 
@@ -226,7 +238,7 @@
   <changeSet author="task" id="1.0.0-12">
     <validCheckSum>ANY</validCheckSum>
     <createTable tableName="TASK_USER_SETTINGS">
-      <column name="USERNAME" type="NVARCHAR(50)">
+      <column name="USERNAME" type="VARCHAR(50)">
         <constraints primaryKey="true" primaryKeyName="PK_TASK_USER_SETTINGS" nullable="false"/>
       </column>
       <column name="SHOW_HIDDEN_PROJECT" type="BOOLEAN" defaultValueBoolean="false">
@@ -237,13 +249,15 @@
       </column>
     </createTable>
     <modifySql dbms="mysql">
-      <append value=" ENGINE=INNODB CHARSET=UTF8 COLLATE utf8_general_ci"/>
+      <append value=" ENGINE=INNODB CHARSET=UTF8MB4 COLLATE utf8mb4_0900_ai_ci"/>
     </modifySql>
   </changeSet>
   <!-- Definition of TASK_HIDDEN_PROJECTS table -->
   <changeSet author="task" id="1.0.0-13">
+    <validCheckSum>9:6f1309c6100fa12ca63f66d691c9bd00</validCheckSum>
+    <validCheckSum>9:4691bb72751339dc339998fa7bbf75c3</validCheckSum>
     <createTable tableName="TASK_HIDDEN_PROJECTS">
-      <column name="USERNAME" type="NVARCHAR(50)">
+      <column name="USERNAME" type="VARCHAR(50)">
         <constraints foreignKeyName="FK_TK_HID_PRJ_TK_USR_SET_01" references="TASK_USER_SETTINGS(USERNAME)" nullable="false"/>
       </column>
       <column name="PROJECT_ID" type="BIGINT">
@@ -251,12 +265,14 @@
       </column>
     </createTable>
     <modifySql dbms="mysql">
-      <append value=" ENGINE=INNODB CHARSET=UTF8 COLLATE utf8_general_ci"/>
+      <append value=" ENGINE=INNODB CHARSET=UTF8MB4 COLLATE utf8mb4_0900_ai_ci"/>
     </modifySql>
   </changeSet>
   
   <!-- Definition of TASK_LOGS table -->
   <changeSet author="task" id="1.0.0-14">
+    <validCheckSum>9:9a1e0b5f3156447c9944502a4f07d1b5</validCheckSum>
+    <validCheckSum>9:795d360069999e32a01fc61ca36235cc</validCheckSum>
     <createTable tableName="TASK_CHANGE_LOGS">
       <column name="CHANGE_LOG_ID" type="BIGINT" autoIncrement="${autoIncrement}" startWith="1">
         <constraints primaryKey="true" primaryKeyName="PK_TASK_CHANGE_LOG" nullable="false"/>
@@ -264,20 +280,20 @@
       <column name="TASK_ID" type="BIGINT">
         <constraints nullable="false" foreignKeyName="FK_LOG_TASK" references="TASK_TASKS(TASK_ID)"/>
       </column>
-      <column name="AUTHOR" type="NVARCHAR(100)">
+      <column name="AUTHOR" type="VARCHAR(100)">
         <constraints nullable="false"/>
       </column>
-      <column name="ACTION_NAME" type="NVARCHAR(2000)">
+      <column name="ACTION_NAME" type="VARCHAR(2000)">
         <constraints nullable="false"/>
       </column>
-      <column name="TARGET" type="NVARCHAR(100)">
+      <column name="TARGET" type="VARCHAR(100)">
       </column>
       <column name="CREATED_TIME" type="BIGINT">
         <constraints nullable="false"/>
       </column>
     </createTable>
     <modifySql dbms="mysql">
-      <append value=" ENGINE=INNODB CHARSET=UTF8 COLLATE utf8_general_ci"/>
+      <append value=" ENGINE=INNODB CHARSET=UTF8MB4 COLLATE utf8mb4_0900_ai_ci"/>
     </modifySql>
   </changeSet>
 
@@ -290,15 +306,15 @@
     </createIndex>
     <createIndex indexName="IDX_TASK_PRJ_MGR_01"
                  tableName="TASK_PROJECT_MANAGERS">
-      <column name="MANAGER" type="NVARCHAR(50)"/>
+      <column name="MANAGER" type="VARCHAR(50)"/>
     </createIndex>
     <createIndex indexName="IDX_TASK_PRJ_PTOR_01"
                  tableName="TASK_PROJECT_PARTICIPATORS">
-      <column name="PARTICIPATOR" type="NVARCHAR(50)"/>
+      <column name="PARTICIPATOR" type="VARCHAR(50)"/>
     </createIndex>
     <createIndex indexName="IDX_TASK_TASK_COWORKERS_01"
                  tableName="TASK_TASK_COWORKERS">
-      <column name="COWORKER" type="NVARCHAR(50)"/>
+      <column name="COWORKER" type="VARCHAR(50)"/>
     </createIndex>
   </changeSet>
 
@@ -341,8 +357,9 @@
 
   <!-- Definition column ACTIVITY_ID for TASK_TASKS table -->
   <changeSet author="task" id="1.0.0-18">
+    <validCheckSum>9:ae4fd6604c99946d9a09bd0b98e01e22</validCheckSum>
     <addColumn tableName="TASK_TASKS">
-      <column name="ACTIVITY_ID" type="NVARCHAR(50)" defaultValue="">
+      <column name="ACTIVITY_ID" type="VARCHAR(50)" defaultValue="">
         <constraints nullable="true"/>
       </column>
     </addColumn>
@@ -355,13 +372,13 @@
       <column name="LABEL_ID" type="BIGINT" autoIncrement="${autoIncrement}" startWith="1">
         <constraints nullable="false" primaryKey="true" primaryKeyName="PK_TASK_LABELS"/>
       </column>
-      <column name="NAME" type="NVARCHAR(50)">
+      <column name="NAME" type="VARCHAR(50)">
         <constraints nullable="false"/>
       </column>
-      <column name="USERNAME" type="NVARCHAR(50)">
+      <column name="USERNAME" type="VARCHAR(50)">
         <constraints nullable="false"/>
       </column>
-      <column name="COLOR" type="NVARCHAR(100)">
+      <column name="COLOR" type="VARCHAR(100)">
         <constraints nullable="true"/>
       </column>
       <column name="HIDDEN" type="BOOLEAN" defaultValueBoolean="false">
@@ -372,12 +389,13 @@
       </column>
     </createTable>
     <modifySql dbms="mysql">
-      <append value=" ENGINE=INNODB CHARSET=UTF8 COLLATE utf8_general_ci"/>
+      <append value=" ENGINE=INNODB CHARSET=UTF8MB4 COLLATE utf8mb4_0900_ai_ci"/>
     </modifySql>
   </changeSet>
   
   <!-- Definition of TASK_LABEL_TASK table -->
   <changeSet author="task" id="1.0.0-20">
+    <validCheckSum>9:364131526a986ac3f251e333323427a5</validCheckSum>
     <createTable tableName="TASK_LABEL_TASK">
       <column name="LABEL_ID" type="BIGINT">
         <constraints foreignKeyName="FK_TK_LBL_TK_LBL_TK_LBL__01" references="TASK_LABELS(LABEL_ID)" nullable="false"/>
@@ -387,7 +405,7 @@
       </column>
     </createTable>
     <modifySql dbms="mysql">
-      <append value=" ENGINE=INNODB CHARSET=UTF8 COLLATE utf8_general_ci"/>
+      <append value=" ENGINE=INNODB CHARSET=UTF8MB4 COLLATE utf8mb4_0900_ai_ci"/>
     </modifySql>    
   </changeSet>
 
@@ -405,17 +423,17 @@
   <changeSet author="task" id="1.0.0-23">
     <createIndex indexName="IDX_TASK_LABELS_01"
                  tableName="TASK_LABELS">
-      <column name="USERNAME" type="NVARCHAR(50)"/>
+      <column name="USERNAME" type="VARCHAR(50)"/>
     </createIndex>
   </changeSet>
   <changeSet author="task" id="1.0.0-24">
     <createIndex indexName="IDX_TASK_TASKS_02"
                  tableName="TASK_TASKS">
-      <column name="ASSIGNEE" type="NVARCHAR(50)"/>
+      <column name="ASSIGNEE" type="VARCHAR(50)"/>
     </createIndex>
     <createIndex indexName="IDX_TASK_TASKS_03"
                  tableName="TASK_TASKS">
-      <column name="CREATED_BY" type="NVARCHAR(50)"/>
+      <column name="CREATED_BY" type="VARCHAR(50)"/>
     </createIndex>
   </changeSet>
 
@@ -458,36 +476,39 @@
   </changeSet>
 
   <changeSet author="task" id="1.0.0-29">
+    <validCheckSum>9:5ce9a3049a83496cb667e227a14feb1b</validCheckSum>
     <modifyDataType columnName="NAME"
-                    newDataType="NVARCHAR(200)"
+                    newDataType="VARCHAR(200)"
                     tableName="TASK_PROJECTS"/>
     <modifyDataType columnName="MANAGER"
-                    newDataType="NVARCHAR(250)"
+                    newDataType="VARCHAR(250)"
                     tableName="TASK_PROJECT_MANAGERS"/>
     <modifyDataType columnName="PARTICIPATOR"
-                    newDataType="NVARCHAR(250)"
+                    newDataType="VARCHAR(250)"
                     tableName="TASK_PROJECT_PARTICIPATORS"/>
   </changeSet>
 
   <!-- Definition of TASK_TASK_WATCHERS table -->
   <changeSet author="task" id="1.0.0-30">
+    <validCheckSum>9:656a057c93bb8fea3062fba007db412f</validCheckSum>
+    <validCheckSum>9:45553c25db19492340c6ce360aaa0a77</validCheckSum>
     <createTable tableName="TASK_TASK_WATCHERS">
       <column name="TASK_ID" type="BIGINT">
         <constraints foreignKeyName="FK_TK_TK_WATCHERS_TK_TK_01" references="TASK_TASKS(TASK_ID)" nullable="false"/>
       </column>
-      <column name="WATCHER" type="NVARCHAR(50)">
+      <column name="WATCHER" type="VARCHAR(50)">
         <constraints nullable="false"/>
       </column>
     </createTable>
     <modifySql dbms="mysql">
-      <append value=" ENGINE=INNODB CHARSET=UTF8 COLLATE utf8_general_ci"/>
+      <append value=" ENGINE=INNODB CHARSET=UTF8MB4 COLLATE utf8mb4_0900_ai_ci"/>
     </modifySql>
   </changeSet>
 
   <changeSet author="task" id="1.0.0-31">
     <createIndex indexName="IDX_TASK_TASK_WATCHERS_01"
                  tableName="TASK_TASK_WATCHERS">
-      <column name="WATCHER" type="NVARCHAR(50)"/>
+      <column name="WATCHER" type="VARCHAR(50)"/>
     </createIndex>
   </changeSet>
 
@@ -507,8 +528,9 @@
 
   <!-- Update the size of DESCRIPTION column for the table TASK_TASKS -->
   <changeSet author="task" id="1.0.0-34">
+    <validCheckSum>9:a6123fa049de4515c4f8fd850bb6de7f</validCheckSum>
     <modifyDataType columnName="DESCRIPTION"
-                    newDataType="NVARCHAR(4000)"
+                    newDataType="VARCHAR(4000)"
                     tableName="TASK_TASKS"/>
   </changeSet>
 
@@ -528,6 +550,23 @@
   <changeSet author="task" id="1.0.0-37" dbms="mysql">
     <sql>
       ALTER TABLE TASK_PROJECTS MODIFY COLUMN NAME varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+    </sql>
+  </changeSet>
+  <changeSet author="task" id="1.0.0-38">
+    <sql dbms="mysql">
+      ALTER TABLE TASK_PROJECTS CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+      ALTER TABLE TASK_PROJECT_MANAGERS CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+      ALTER TABLE TASK_PROJECT_PARTICIPATORS CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+      ALTER TABLE TASK_STATUS CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+      ALTER TABLE TASK_TASKS CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+      ALTER TABLE TASK_TASK_COWORKERS CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+      ALTER TABLE TASK_COMMENTS CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+      ALTER TABLE TASK_USER_SETTINGS CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+      ALTER TABLE TASK_HIDDEN_PROJECTS CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+      ALTER TABLE TASK_CHANGE_LOGS CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+      ALTER TABLE TASK_LABELS CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+      ALTER TABLE TASK_LABEL_TASK CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+      ALTER TABLE TASK_TASK_WATCHERS CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
     </sql>
   </changeSet>
 </databaseChangeLog>

--- a/services/src/main/resources/db/changelog/task.db.changelog-1.1.0.xml
+++ b/services/src/main/resources/db/changelog/task.db.changelog-1.1.0.xml
@@ -33,7 +33,7 @@
         <column name="TASK_ID" type="BIGINT">
           <constraints foreignKeyName="FK_TASK_TAGS_TASK_TASKS_01" references="TASK_TASKS(TASK_ID)" nullable="false"/>
         </column>
-        <column name="TAG" type="NVARCHAR(50)">
+        <column name="TAG" type="VARCHAR(50)">
           <constraints nullable="false"/>
         </column>
       </createTable>

--- a/services/src/main/resources/db/changelog/task.db.changelog-2.1.0.xml
+++ b/services/src/main/resources/db/changelog/task.db.changelog-2.1.0.xml
@@ -23,6 +23,8 @@
 
   <!-- Definition of TASK_COMMENT_MENTIONED_USERS table -->
   <changeSet author="task" id="2.1.0-01">
+    <validCheckSum>9:cea5fbf26104ec61ae0b199636c8afbe</validCheckSum>
+    <validCheckSum>9:e3e8a66f56c6250bfb92e0614a7aa778</validCheckSum>
     <preConditions onFail="MARK_RAN">
       <not><tableExists tableName="TASK_COMMENT_MENTIONED_USERS"/></not>
     </preConditions>
@@ -30,12 +32,12 @@
       <column name="COMMENT_ID" type="BIGINT">
         <constraints foreignKeyName="FK_TK_CM_MENT_TK_CM_01" references="TASK_COMMENTS(COMMENT_ID)" nullable="false"/>
       </column>
-      <column name="MENTIONED_USERS" type="NVARCHAR(50)">
+      <column name="MENTIONED_USERS" type="VARCHAR(50)">
         <constraints nullable="false"/>
       </column>
     </createTable>
     <modifySql dbms="mysql">
-      <append value=" ENGINE=INNODB CHARSET=UTF8 COLLATE utf8_general_ci"/>
+      <append value=" ENGINE=INNODB CHARSET=UTF8MB4 COLLATE utf8mb4_0900_ai_ci"/>
     </modifySql>
   </changeSet>
 
@@ -45,8 +47,13 @@
     </preConditions>
     <createIndex indexName="IDX_TASK_COMMENT_MENTIONED_USERS_01"
                  tableName="TASK_COMMENT_MENTIONED_USERS">
-      <column name="MENTIONED_USERS" type="NVARCHAR(50)"/>
+      <column name="MENTIONED_USERS" type="VARCHAR(50)"/>
     </createIndex>
   </changeSet>
 
+  <changeSet author="task" id="2.1.0-03">
+    <sql dbms="mysql">
+      ALTER TABLE TASK_COMMENT_MENTIONED_USERS CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
+    </sql>
+  </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
With mysql 8.4, the default charset and collation are updated from UTF to UTF8MB4. In addition NVARCHAR is now deprecated and replaced by VARCHAR. This commit adapt liquibase changes in order to apply this change.

Resolves Meeds-io/meeds#2564

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
