### PR TITLE
fix: Fix display space favorite icon when hovering on space name in a task project card - MEED-8142 - Meeds-io/meeds#1834

### DIFF
--- a/webapps/src/main/webapp/vue-app/tasks-management/components/Project/ProjectCardFront.vue
+++ b/webapps/src/main/webapp/vue-app/tasks-management/components/Project/ProjectCardFront.vue
@@ -284,7 +284,7 @@ export default {
       }
     },
     retrieveSpaceInformation(spaceId) {
-      this.$spaceService.getSpaceById(spaceId).then(space => {
+      this.$spaceService.getSpaceById(spaceId, 'favorite').then(space => {
         this.projectSpace = space;
       });
     }


### PR DESCRIPTION
This PR will fix display space favorite icon when hovering on space name in a task project card