### PR TITLE
fix : Create an activity with ++ generates a server error in logs - MEED-8573

### DIFF
--- a/services/src/main/resources/META-INF/services/org.exoplatform.task.service.TaskParserPlugin
+++ b/services/src/main/resources/META-INF/services/org.exoplatform.task.service.TaskParserPlugin
@@ -1,1 +1,0 @@
-org.exoplatform.task.legacy.service.impl.DefaultParserPlugin


### PR DESCRIPTION
Before this fix, a TaskParser is load from classLoader : org.exoplatform.task.legacy.service.impl.DefaultParserPlugin This class no more exists.
This commit removes the configuration which loads this class.

Resolved meeds-io/meeds#3084

<!-- Ensure to provide github issue and task id in the title -->
<!-- Choose between feat and fix in the title to differenciate a new feature from a fix -->
<!-- Title format must be :
feat: FEATURE TITLE - MEED-XXXX - meeds-io/meeds#1234
or
fix: Fix TITLE - MEED-XXXX - meeds-io/meeds#1234
-->

<!-- Description : describe the feature/the fix by answering theses questions : -->
<!-- Why is this change needed?-->
<!-- Prior to this change, ...-->
<!-- How does it address the issue?-->
<!-- This change ...-->


<!-- Tips : 
Try To Limit Each Line to a Maximum Of 72 Characters
Provide links or keys to any relevant tickets, articles or other resources

Remember to
- Capitalize the subject line
- Use the imperative mood in the subject line
- Do not end the subject line with a period
- Separate subject from body with a blank line
- Use the body to explain what and why vs. how
- Can use multiple lines with "-" for bullet points in body
-->
