### PR TITLE
fix: Providing an alternative text for project manager avatars - MEED-8968 - Meeds-io/meeds#3259

### DIFF
--- a/webapps/src/main/resources/locale/portlet/taskManagement_en.properties
+++ b/webapps/src/main/resources/locale/portlet/taskManagement_en.properties
@@ -219,6 +219,9 @@ label.ganttView=Plan
 label.cardsView=Cards
 label.start.adding.tasks=Add Tasks
 
+#project card
+project.card.managerAvatar.alt=Manager of {0}: {1}
+
 #status tasks
 tasks.status.ToDo=To Do
 tasks.status.InProgress=In Progress

--- a/webapps/src/main/webapp/vue-app/tasks-management/components/Project/ProjectCardFront.vue
+++ b/webapps/src/main/webapp/vue-app/tasks-management/components/Project/ProjectCardFront.vue
@@ -120,6 +120,7 @@
             :profile-id="avatarToDisplay[0].userName"
             :size="28"
             :extra-class="'my-2'"
+            :alt="avatarToDisplay[0].alt"
             link-style
             popover />
           <div
@@ -206,7 +207,8 @@ export default {
       const projectManagersList = [];
       if ( this.managerIdentities && this.managerIdentities.length ) {
         this.managerIdentities.forEach((manager) => {
-          projectManagersList.push({'userName': manager.username});
+          manager.alt=`${this.$t('project.card.managerAvatar.alt', {0: this.project.name,1: manager.username})}`;
+          projectManagersList.push({'userName': manager.username, 'alt': manager.alt});
         });
       }
       return projectManagersList;


### PR DESCRIPTION
Before this change, when accessing projects board, the Avatar of the project manager contains an empty alt. To fix this problem, add an alt in avatarToDisplay. After this change, avatars provide information about project managers they are contains an alt as alt=Manager of [Project name]: [User name].
