### PR TITLE
fix: Providing an alternative text for Task Assignees and Coworkers avatars - MEED-8930 - Meeds-io/meeds#3259

### DIFF
--- a/webapps/src/main/resources/locale/portlet/taskManagement_en.properties
+++ b/webapps/src/main/resources/locale/portlet/taskManagement_en.properties
@@ -222,6 +222,9 @@ label.start.adding.tasks=Add Tasks
 #project card
 project.card.managerAvatar.alt=Manager of {0}: {1}
 
+#task view card
+task.card.userAvatar.alt=Task Assignee or Coworker: {0}
+
 #status tasks
 tasks.status.ToDo=To Do
 tasks.status.InProgress=In Progress

--- a/webapps/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TaskViewCard.vue
+++ b/webapps/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TaskViewCard.vue
@@ -159,7 +159,8 @@ export default {
       if (this.assigneeAndCoworkerArray && this.assigneeAndCoworkerArray.length ) {
         this.assigneeAndCoworkerArray.forEach(user => {
           if (!usersList.includes({'userName': user.username})) {
-            usersList.push({'userName': user.username});
+            user.alt=`${this.$t('task.card.userAvatar.alt', {0: user.username})}`;
+            usersList.push({'userName': user.username, 'alt': user.alt});
           }
         });
       }


### PR DESCRIPTION
Before this change, when access to any project containing assigned tasks (or having coworker), the avatar of the task assigned or coworker contains an empty alt. To fix this problem, add an alt attribute to the avatarToDisplay user object. After this change, avatars provide information about assignment so they must contain an alt as alt=Task Assignee or Coworker: [User name].