### PR TITLE
fix: Task board filtered to labels is not filtered anymore when refreshed - MEED-9027 - Meeds-io/meeds#1216

### DIFF
--- a/webapps/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TasksViewDashboard.vue
+++ b/webapps/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TasksViewDashboard.vue
@@ -418,7 +418,8 @@ export default {
       this.filterByStatus=false;
     },
     filterTaskDashboard(e) {
-      this.searchedLabels = e.filterLabels.labels;      
+      this.searchedLabels = e.filterLabels.labels;  
+      localStorage.setItem('searchedLabels', this.searchedLabels);
       this.loadingTasks = true;
       this.tasksFilter = e.tasks;
       this.showCompletedTasks = e.showCompletedTasks;
@@ -555,7 +556,15 @@ export default {
           this.tasksList = data && data.tasks || [];
         }).finally(() => this.loadingTasks = false);
       } else {
-        this.$tasksService.filterTasksList(this.tasksFilter, '', '', '', ProjectId).then(data => {
+        this.searchedLabels = localStorage.getItem('searchedLabels');   
+        const projectStorage = localStorage.getItem('projectStorage')
+        const labelsToUse =  projectStorage == this.project.id ? this.searchedLabels : '';
+        if(labelsToUse == ''){
+          localStorage.removeItem('searchedLabels');
+          localStorage.removeItem('filtersNumber');
+          localStorage.removeItem('labelsStorage');
+        }      
+        this.$tasksService.filterTasksList(this.tasksFilter, '', '', labelsToUse, ProjectId).then(data => {
           this.filterByStatus = false;
           if (data.projectName) {
             this.filterProjectActive = true;

--- a/webapps/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TasksViewDashboard.vue
+++ b/webapps/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TasksViewDashboard.vue
@@ -557,9 +557,9 @@ export default {
         }).finally(() => this.loadingTasks = false);
       } else {
         this.searchedLabels = localStorage.getItem('searchedLabels');   
-        const projectStorage = localStorage.getItem('projectStorage')
-        const labelsToUse =  projectStorage == this.project.id ? this.searchedLabels : '';
-        if(labelsToUse == ''){
+        const projectStorage = localStorage.getItem('projectStorage');
+        const labelsToUse =  projectStorage === this.project.id ? this.searchedLabels : '';
+        if (labelsToUse === ''){
           localStorage.removeItem('searchedLabels');
           localStorage.removeItem('filtersNumber');
           localStorage.removeItem('labelsStorage');

--- a/webapps/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TasksViewDashboard.vue
+++ b/webapps/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TasksViewDashboard.vue
@@ -559,7 +559,7 @@ export default {
         this.searchedLabels = localStorage.getItem('searchedLabels');   
         const projectStorage = localStorage.getItem('projectStorage');
         const labelsToUse =  projectStorage === this.project.id ? this.searchedLabels : '';
-        if (labelsToUse === ''){
+        if (labelsToUse === '') {
           localStorage.removeItem('searchedLabels');
           localStorage.removeItem('filtersNumber');
           localStorage.removeItem('labelsStorage');

--- a/webapps/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TasksViewToolbar.vue
+++ b/webapps/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TasksViewToolbar.vue
@@ -173,6 +173,8 @@ export default {
       this.filterNumber=filtersnumber;
     },
     getFilterNum(){
+    const numOfFilter = localStorage.getItem('filtersNumber');
+    this.filterNumber=Number(numOfFilter);
       if (this.filterNumber>0){
         return `(${this.filterNumber})`;
       } return '';

--- a/webapps/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TasksViewToolbar.vue
+++ b/webapps/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TasksViewToolbar.vue
@@ -173,8 +173,8 @@ export default {
       this.filterNumber=filtersnumber;
     },
     getFilterNum(){
-    const numOfFilter = localStorage.getItem('filtersNumber');
-    this.filterNumber=Number(numOfFilter);
+      const numOfFilter = localStorage.getItem('filtersNumber');
+      this.filterNumber=Number(numOfFilter);
       if (this.filterNumber>0){
         return `(${this.filterNumber})`;
       } return '';

--- a/webapps/src/main/webapp/vue-app/tasks-management/components/tasks/TasksFilterDrawer.vue
+++ b/webapps/src/main/webapp/vue-app/tasks-management/components/tasks/TasksFilterDrawer.vue
@@ -440,9 +440,11 @@ export default {
       if (this.showCompletedTasks){
         filtersnumber++;
       }
+      localStorage.setItem('filtersNumber', JSON.stringify(filtersnumber));
       this.$emit('filter-num-changed',filtersnumber,source);
     },
     saveValueFilterInStorage(value) {
+      localStorage.setItem('projectStorage', JSON.stringify(this.project));
       this.$projectService.saveFilterSettings(value).then((response) => {
         if (response) {
           value.showCompletedTasks = this.showCompletedTasks;

--- a/webapps/src/main/webapp/vue-app/tasks-management/components/tasks/TasksLabelsDrawer.vue
+++ b/webapps/src/main/webapp/vue-app/tasks-management/components/tasks/TasksLabelsDrawer.vue
@@ -109,12 +109,16 @@ export default {
           return v;
         });
       }
-
+      localStorage.setItem('labelsStorage', JSON.stringify(this.model));
       this.$root.$emit('filter-task-labels',this.model);
     },
 
   },
   created() {
+    const labelsStorage = localStorage.getItem('labelsStorage');
+    if (labelsStorage) {
+      this.model = JSON.parse(labelsStorage);
+    }
     const urlPath = document.location.pathname;
     if (urlPath.includes('projectDetail')){
       let projectId = urlPath.split('projectDetail/')[1].split(/[^0-9]/)[0];


### PR DESCRIPTION
Prior to this change, when a user filter tasks by labels and then reload the page, the board is refreshed and all tasks are displayed and the filter button no longer retains the number of parameters with which the search will be based on.
After this change, the labels to be searched and the number of parameters are stored in localStorage sessions so the data persists.

Resolves https://github.com/meeds-io/meeds/issues/1216