### PR TITLE
fix: Providing an explicit label for Task Assignees and Coworkers - MEED-8930 - Meeds-io/meeds#3259

### DIFF
--- a/webapps/src/main/resources/locale/portlet/taskManagement_en.properties
+++ b/webapps/src/main/resources/locale/portlet/taskManagement_en.properties
@@ -223,7 +223,10 @@ label.start.adding.tasks=Add Tasks
 project.card.managerAvatar.ariaLabel=Open list of managers
 
 #task view card
-task.card.userAvatar.alt=Task Assignee or Coworker: {0}
+task.card.userAvatar.ariaLabel=Open list of assignees and coworkers
+
+#task drawer
+task.drawer.userAvatar.ariaLabel=Edit assignees and coworkers
 
 #status tasks
 tasks.status.ToDo=To Do

--- a/webapps/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskAssignment.vue
+++ b/webapps/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskAssignment.vue
@@ -39,6 +39,7 @@
               :profile-id="taskAssigneeObj.remoteId"
               :url="null"
               :size="24"
+              :aria-label="$t('task.drawer.userAvatar.ariaLabel')"
               extra-class="pe-2 overflow-hidden"
               popover />
           </div>

--- a/webapps/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TaskViewCard.vue
+++ b/webapps/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TaskViewCard.vue
@@ -159,8 +159,8 @@ export default {
       if (this.assigneeAndCoworkerArray && this.assigneeAndCoworkerArray.length ) {
         this.assigneeAndCoworkerArray.forEach(user => {
           if (!usersList.includes({'userName': user.username})) {
-            user.alt=`${this.$t('task.card.userAvatar.alt', {0: user.username})}`;
-            usersList.push({'userName': user.username, 'alt': user.alt});
+            user.ariaLabel=`${this.$t('task.card.userAvatar.ariaLabel')}`;
+            usersList.push({'userName': user.username, 'ariaLabel': user.ariaLabel});
           }
         });
       }


### PR DESCRIPTION
Before this change, when access to any project containing assigned tasks (or having coworker), Avatars of the task assigned or coworker are buttons that contain aria-label= Open Full name profile. To fix this problem, add an aria-label attribute to the avatarToDisplay user object. After this change, avatars provide information about assignment so they must contain an aria-label as aria-label=Open list of assignees and coworkers. Resolves https://github.com/Meeds-io/meeds/issues/3259