### PR TITLE
fix: Task- Providing an explicit label for project managers - MEED-8968 - Meeds-io/meeds#3275

### DIFF
--- a/webapps/src/main/resources/locale/portlet/taskManagement_en.properties
+++ b/webapps/src/main/resources/locale/portlet/taskManagement_en.properties
@@ -220,7 +220,7 @@ label.cardsView=Cards
 label.start.adding.tasks=Add Tasks
 
 #project card
-project.card.managerAvatar.alt=Manager of {0}: {1}
+project.card.managerAvatar.ariaLabel=Open list of managers
 
 #status tasks
 tasks.status.ToDo=To Do

--- a/webapps/src/main/resources/locale/portlet/taskManagement_en.properties
+++ b/webapps/src/main/resources/locale/portlet/taskManagement_en.properties
@@ -219,6 +219,9 @@ label.ganttView=Plan
 label.cardsView=Cards
 label.start.adding.tasks=Add Tasks
 
+#project card
+project.card.managerAvatar.alt=Manager of {0}: {1}
+
 #status tasks
 tasks.status.ToDo=To Do
 tasks.status.InProgress=In Progress

--- a/webapps/src/main/webapp/vue-app/tasks-management/components/Project/ProjectCardFront.vue
+++ b/webapps/src/main/webapp/vue-app/tasks-management/components/Project/ProjectCardFront.vue
@@ -120,7 +120,6 @@
             :profile-id="avatarToDisplay[0].userName"
             :size="28"
             :extra-class="'my-2'"
-            :alt="avatarToDisplay[0].alt"
             link-style
             popover />
           <div
@@ -207,8 +206,8 @@ export default {
       const projectManagersList = [];
       if ( this.managerIdentities && this.managerIdentities.length ) {
         this.managerIdentities.forEach((manager) => {
-          manager.alt=`${this.$t('project.card.managerAvatar.alt', {0: this.project.name,1: manager.username})}`;
-          projectManagersList.push({'userName': manager.username, 'alt': manager.alt});
+          manager.ariaLabel=`${this.$t('project.card.managerAvatar.ariaLabel')}`;
+          projectManagersList.push({'userName': manager.username, 'ariaLabel': manager.ariaLabel});
         });
       }
       return projectManagersList;

--- a/webapps/src/main/webapp/vue-app/tasks-management/components/Project/ProjectCardFront.vue
+++ b/webapps/src/main/webapp/vue-app/tasks-management/components/Project/ProjectCardFront.vue
@@ -120,6 +120,7 @@
             :profile-id="avatarToDisplay[0].userName"
             :size="28"
             :extra-class="'my-2'"
+            :alt="avatarToDisplay[0].alt"
             link-style
             popover />
           <div
@@ -206,7 +207,8 @@ export default {
       const projectManagersList = [];
       if ( this.managerIdentities && this.managerIdentities.length ) {
         this.managerIdentities.forEach((manager) => {
-          projectManagersList.push({'userName': manager.username});
+          manager.alt=`${this.$t('project.card.managerAvatar.alt', {0: this.project.name,1: manager.username})}`;
+          projectManagersList.push({'userName': manager.username, 'alt': manager.alt});
         });
       }
       return projectManagersList;


### PR DESCRIPTION
Before this change, when accessing projects board, the Avatar of the project manager contains that contain aria-label= Open Full name profile. To fix this problem, add an aria-label props to the user-avatar component and pass the requested value. After this change, avatars provide information about project managers they are contains an aria-label equal to Open list of managers if there is more than one project manager. 
Resolves https://github.com/Meeds-io/meeds/issues/3275