### PR TITLE
fix: Upgrade Hibernate to version 6.6 - Meeds-io/meeds#3365

### DIFF
--- a/services/pom.xml
+++ b/services/pom.xml
@@ -99,6 +99,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
+          <runOrder>alphabetical</runOrder>
           <systemPropertyVariables>
             <gatein.test.tmp.dir>${project.build.directory}/datadir</gatein.test.tmp.dir>
             <exo.files.storage.dir>${project.build.directory}/datadir</exo.files.storage.dir>

--- a/services/src/main/java/org/exoplatform/task/dao/jpa/StatusDAOImpl.java
+++ b/services/src/main/java/org/exoplatform/task/dao/jpa/StatusDAOImpl.java
@@ -16,23 +16,18 @@
  */
 package org.exoplatform.task.dao.jpa;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.NoResultException;
-import jakarta.persistence.Query;
-import jakarta.persistence.TypedQuery;
 
 import org.apache.commons.lang3.StringUtils;
 
-import org.exoplatform.commons.persistence.impl.EntityManagerService;
-import org.exoplatform.commons.persistence.impl.GenericDAOJPAImpl;
 import org.exoplatform.task.dao.StatusHandler;
 import org.exoplatform.task.domain.Status;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import jakarta.persistence.TypedQuery;
 
 /**
  * Created by The eXo Platform SAS
@@ -103,5 +98,6 @@ public class StatusDAOImpl extends CommonJPADAO<Status, Long> implements StatusH
     }
     return cloneEntities(q.getResultList());
   }
+
 }
 

--- a/services/src/main/java/org/exoplatform/task/dao/jpa/TaskDAOImpl.java
+++ b/services/src/main/java/org/exoplatform/task/dao/jpa/TaskDAOImpl.java
@@ -34,6 +34,7 @@ import jakarta.persistence.criteria.Path;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
 
+import org.exoplatform.commons.api.persistence.ExoTransactional;
 import org.exoplatform.commons.utils.ListAccess;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
@@ -57,25 +58,8 @@ public class TaskDAOImpl extends CommonJPADAO<Task, Long> implements TaskHandler
   public TaskDAOImpl() {
   }
 
-  /*@Override
-  public void delete(Task entity) {
-    EntityManager em = getEntityManager();
-    Task task = em.find(Task.class, entity.getId());
-
-    // Delete all task log relate to this task
-    Query query = em.createNamedQuery("TaskChangeLog.removeChangeLogByTaskId");
-    query.setParameter("taskId", entity.getId());
-    query.executeUpdate();
-
-    // Delete all comments of task
-    query = em.createNamedQuery("Comment.deleteCommentOfTask");
-    query.setParameter("taskId", entity.getId());
-    query.executeUpdate();
-
-    em.remove(task);
-  }*/
-
   @Override
+  @ExoTransactional
   public void updateStatus(Status stOld, Status stNew) {
     Query query = getEntityManager().createNamedQuery("Task.updateStatus");
     query.setParameter("status_old", stOld);

--- a/services/src/main/java/org/exoplatform/task/domain/ChangeLog.java
+++ b/services/src/main/java/org/exoplatform/task/domain/ChangeLog.java
@@ -16,8 +16,6 @@
  */
 package org.exoplatform.task.domain;
 
-import org.exoplatform.commons.api.persistence.ExoEntity;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -31,7 +29,6 @@ import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 
 @Entity(name = "TaskChangeLog")
-@ExoEntity
 @Table(name = "TASK_CHANGE_LOGS")
 @NamedQueries({
         @NamedQuery(name = "TaskChangeLog.findChangeLogByTaskId",

--- a/services/src/main/java/org/exoplatform/task/domain/Comment.java
+++ b/services/src/main/java/org/exoplatform/task/domain/Comment.java
@@ -16,20 +16,37 @@
  */
 package org.exoplatform.task.domain;
 
-import java.util.*;
-import java.util.regex.Matcher;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import jakarta.persistence.*;
-
-import org.exoplatform.commons.api.persistence.ExoEntity;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.NamedQueries;
+import jakarta.persistence.NamedQuery;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import jakarta.persistence.Temporal;
+import jakarta.persistence.TemporalType;
 
 /**
  * @author <a href="mailto:tuyennt@exoplatform.com">Tuyen Nguyen The</a>.
  */
 @Entity(name = "TaskComment")
-@ExoEntity
 @Table(name = "TASK_COMMENTS")
 @NamedQueries({
                 @NamedQuery(name = "Comment.countCommentOfTask",

--- a/services/src/main/java/org/exoplatform/task/domain/Label.java
+++ b/services/src/main/java/org/exoplatform/task/domain/Label.java
@@ -16,17 +16,25 @@
  */
 package org.exoplatform.task.domain;
 
-import jakarta.persistence.*;
-
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 
-import org.exoplatform.commons.api.persistence.ExoEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.NamedQuery;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
 
 @Entity(name = "TaskLabel")
-@ExoEntity
 @Table(name = "TASK_LABELS")
 @NamedQuery(name = "Label.findLabelsByTask",
   query = "SELECT lbl FROM TaskLabel lbl inner join lbl.lblMapping m WHERE lbl.project.id = :projectId AND m.task.id = :taskid ORDER BY lbl.id")

--- a/services/src/main/java/org/exoplatform/task/domain/LabelTaskMapping.java
+++ b/services/src/main/java/org/exoplatform/task/domain/LabelTaskMapping.java
@@ -16,6 +16,8 @@
  */
 package org.exoplatform.task.domain;
 
+import java.io.Serializable;
+
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
@@ -24,12 +26,7 @@ import jakarta.persistence.NamedQueries;
 import jakarta.persistence.NamedQuery;
 import jakarta.persistence.Table;
 
-import java.io.Serializable;
-
-import org.exoplatform.commons.api.persistence.ExoEntity;
-
 @Entity(name = "TaskLabelTaskMapping")
-@ExoEntity
 @Table(name = "TASK_LABEL_TASK")
 @NamedQueries({  
   @NamedQuery(name = "LabelTaskMapping.removeLabelTaskMapping",

--- a/services/src/main/java/org/exoplatform/task/domain/Project.java
+++ b/services/src/main/java/org/exoplatform/task/domain/Project.java
@@ -16,20 +16,40 @@
  */
 package org.exoplatform.task.domain;
 
-import org.exoplatform.commons.api.persistence.ExoEntity;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+
 import org.exoplatform.services.security.Identity;
 import org.exoplatform.services.security.MembershipEntry;
 import org.exoplatform.task.util.ProjectUtil;
 
-import jakarta.persistence.*;
-
-import java.util.*;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.NamedQueries;
+import jakarta.persistence.NamedQuery;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import jakarta.persistence.Temporal;
+import jakarta.persistence.TemporalType;
 
 /**
  * @author <a href="mailto:tuyennt@exoplatform.com">Tuyen Nguyen The</a>
  */
 @Entity(name = "TaskProject")
-@ExoEntity
 @Table(name = "TASK_PROJECTS")
 @NamedQueries({
   @NamedQuery(

--- a/services/src/main/java/org/exoplatform/task/domain/Status.java
+++ b/services/src/main/java/org/exoplatform/task/domain/Status.java
@@ -16,29 +16,29 @@
  */
 package org.exoplatform.task.domain;
 
-import org.exoplatform.commons.api.persistence.ExoEntity;
-
-import jakarta.persistence.*;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.NamedQueries;
 import jakarta.persistence.NamedQuery;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 
 /**
  * @author <a href="mailto:tuyennt@exoplatform.com">Tuyen Nguyen The</a>
  */
 @Entity(name = "TaskStatus")
-@ExoEntity
 @Table(name = "TASK_STATUS")
 @NamedQueries({
     @NamedQuery(

--- a/services/src/main/java/org/exoplatform/task/domain/Task.java
+++ b/services/src/main/java/org/exoplatform/task/domain/Task.java
@@ -16,7 +16,12 @@
  */
 package org.exoplatform.task.domain;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.CollectionTable;
@@ -31,7 +36,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.NamedQueries;
 import jakarta.persistence.NamedQuery;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.SequenceGenerator;
@@ -39,15 +43,10 @@ import jakarta.persistence.Table;
 import jakarta.persistence.Temporal;
 import jakarta.persistence.TemporalType;
 
-import org.exoplatform.commons.api.persistence.ExoEntity;
-import org.exoplatform.task.dto.StatusDto;
-import org.exoplatform.task.service.TaskBuilder;
-
 /**
  * @author <a href="mailto:tuyennt@exoplatform.com">Tuyen Nguyen The</a>
  */
 @Entity(name = "TaskTask")
-@ExoEntity
 @Table(name = "TASK_TASKS")
 @NamedQuery(
     name = "Task.findByMemberships",

--- a/services/src/main/java/org/exoplatform/task/domain/UserSetting.java
+++ b/services/src/main/java/org/exoplatform/task/domain/UserSetting.java
@@ -16,17 +16,21 @@
  */
 package org.exoplatform.task.domain;
 
-import org.exoplatform.commons.api.persistence.ExoEntity;
-
-import jakarta.persistence.*;
 import java.util.HashSet;
 import java.util.Set;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.Table;
 
 /**
  * @author <a href="mailto:tuyennt@exoplatform.com">Tuyen Nguyen The</a>.
  */
 @Entity(name = "TaskUserSetting")
-@ExoEntity
 @Table(name = "TASK_USER_SETTINGS")
 public class UserSetting {
   @Id

--- a/services/src/main/resources/jpa-entities.idx
+++ b/services/src/main/resources/jpa-entities.idx
@@ -1,8 +1,8 @@
-org.exoplatform.task.domain.Task
-org.exoplatform.task.domain.Status
-org.exoplatform.task.domain.UserSetting
-org.exoplatform.task.domain.Comment
-org.exoplatform.task.domain.Project
 org.exoplatform.task.domain.Label
+org.exoplatform.task.domain.UserSetting
+org.exoplatform.task.domain.Status
 org.exoplatform.task.domain.LabelTaskMapping
 org.exoplatform.task.domain.ChangeLog
+org.exoplatform.task.domain.Task
+org.exoplatform.task.domain.Project
+org.exoplatform.task.domain.Comment

--- a/services/src/test/java/org/exoplatform/task/AbstractTest.java
+++ b/services/src/test/java/org/exoplatform/task/AbstractTest.java
@@ -16,16 +16,12 @@
  */
 package org.exoplatform.task;
 
-import java.sql.SQLException;
-
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.BeforeClass;
 
-import org.exoplatform.commons.persistence.impl.EntityManagerService;
 import org.exoplatform.container.PortalContainer;
 import org.exoplatform.container.component.RequestLifeCycle;
+import org.exoplatform.task.dao.DAOHandler;
 
 /**
  * A base test class for all DAO tests which take responsibility to
@@ -38,27 +34,23 @@ public class AbstractTest {
 
   @Before
   public void initializeContainerAndStartRequestLifecycle() {
-    PortalContainer container = PortalContainer.getInstance();
-
-    //
-    RequestLifeCycle.begin(container);
-    
-    EntityManagerService entityMgrService = (EntityManagerService) container.getComponentInstanceOfType(EntityManagerService.class);
-    entityMgrService.getEntityManager().getTransaction().begin();
+    RequestLifeCycle.begin(PortalContainer.getInstance());
   }
 
   @After
   public void endRequestLifecycle() {
-    PortalContainer container = PortalContainer.getInstance();
-
-    //
-    EntityManagerService entityMgrService = (EntityManagerService) container.getComponentInstanceOfType(EntityManagerService.class);
-    if (entityMgrService.getEntityManager() != null && entityMgrService.getEntityManager().getTransaction() != null
-        && entityMgrService.getEntityManager().getTransaction().isActive()) {
-      entityMgrService.getEntityManager().getTransaction().commit();
-      //
-      RequestLifeCycle.end();
-    }
-
+    RequestLifeCycle.end();
   }
+
+  protected void deleteAll() {
+    RequestLifeCycle.restartTransaction();
+    DAOHandler daoHandler = PortalContainer.getInstance().getComponentInstanceOfType(DAOHandler.class);
+    daoHandler.getLabelHandler().deleteAll();
+    RequestLifeCycle.restartTransaction();
+    daoHandler.getCommentHandler().deleteAll();
+    daoHandler.getTaskHandler().deleteAll();
+    daoHandler.getProjectHandler().deleteAll();
+    daoHandler.getStatusHandler().deleteAll();
+  }
+
 }

--- a/services/src/test/java/org/exoplatform/task/dao/TestCommentDAO.java
+++ b/services/src/test/java/org/exoplatform/task/dao/TestCommentDAO.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 import org.exoplatform.commons.utils.ListAccess;
 import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.container.PortalContainer;
+import org.exoplatform.container.component.RequestLifeCycle;
 import org.exoplatform.task.AbstractTest;
 import org.exoplatform.task.domain.Comment;
 import org.exoplatform.task.domain.Task;
@@ -57,9 +58,7 @@ public class TestCommentDAO extends AbstractTest {
 
   @After
   public void cleanData() {
-    endRequestLifecycle();
-    commentDAO.deleteAll();
-    taskDAO.deleteAll();
+    deleteAll();
   }
 
   @Test

--- a/services/src/test/java/org/exoplatform/task/dao/TestLabelDAO.java
+++ b/services/src/test/java/org/exoplatform/task/dao/TestLabelDAO.java
@@ -45,8 +45,7 @@ public class TestLabelDAO extends AbstractTest {
 
   @After
   public void tearDown() {
-    taskService.getLabelTaskMappingHandler().deleteAll();
-    lblDAO.deleteAll();
+    deleteAll();
   }
   
   @Test

--- a/services/src/test/java/org/exoplatform/task/dao/TestProjectDAO.java
+++ b/services/src/test/java/org/exoplatform/task/dao/TestProjectDAO.java
@@ -27,6 +27,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.exoplatform.commons.utils.ListAccess;
 import org.exoplatform.container.PortalContainer;
+import org.exoplatform.container.component.RequestLifeCycle;
 import org.exoplatform.task.domain.Project;
 import org.exoplatform.task.AbstractTest;
 
@@ -49,7 +50,7 @@ public class TestProjectDAO extends AbstractTest {
 
   @After
   public void tearDown() {
-    pDAO.deleteAll();
+    deleteAll();
   }
 
   @Test

--- a/services/src/test/java/org/exoplatform/task/dao/TestStatusDAO.java
+++ b/services/src/test/java/org/exoplatform/task/dao/TestStatusDAO.java
@@ -20,6 +20,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.exoplatform.container.PortalContainer;
+import org.exoplatform.container.component.RequestLifeCycle;
 import org.exoplatform.task.AbstractTest;
 import org.exoplatform.task.domain.Project;
 import org.exoplatform.task.domain.Status;
@@ -48,7 +49,7 @@ public class TestStatusDAO extends AbstractTest {
 
   @After
   public void tearDown() {
-    sDAO.deleteAll();
+    deleteAll();
   }
 
   @Test
@@ -96,21 +97,21 @@ public class TestStatusDAO extends AbstractTest {
       t.setTitle("testTitle");
       t.setStatus(s2);
       tDAO.create(t);
-      
-      endRequestLifecycle();
-      initializeContainerAndStartRequestLifecycle();    
-      
+
+      RequestLifeCycle.restartTransaction();
+
       StatusHandler handler = daoHandler.getStatusHandler();
       Status st = handler.find(s2.getId());      
       //
       daoHandler.getTaskHandler().updateStatus(st, s1);
-      
+      RequestLifeCycle.restartTransaction();
+
+      st = handler.find(s2.getId());
       st.setProject(null);
       handler.delete(st);
-      
-      endRequestLifecycle();
-      initializeContainerAndStartRequestLifecycle();
-      
+
+      RequestLifeCycle.restartTransaction();
+
       t = tDAO.find(t.getId());
       Assert.assertNotNull(t);
       Assert.assertEquals(s1.getName(), t.getStatus().getName());

--- a/services/src/test/java/org/exoplatform/task/dao/TestTaskDAO.java
+++ b/services/src/test/java/org/exoplatform/task/dao/TestTaskDAO.java
@@ -18,6 +18,7 @@ package org.exoplatform.task.dao;
 
 import org.exoplatform.commons.utils.ListAccess;
 import org.exoplatform.container.PortalContainer;
+import org.exoplatform.container.component.RequestLifeCycle;
 import org.exoplatform.services.listener.ListenerService;
 import org.exoplatform.services.security.ConversationState;
 import org.exoplatform.services.security.Identity;
@@ -87,15 +88,7 @@ public class TestTaskDAO extends AbstractTest {
 
   @After
   public void tearDown() {
-    for (Task t : tDAO.findAll()) {
-      t.setStatus(null);
-    }    
-    tDAO.updateAll(tDAO.findAll());
-    daoHandler.getLabelTaskMappingHandler().deleteAll();
-    daoHandler.getTaskLogHandler().deleteAll();
-    cDAO.deleteAll();
-    tDAO.deleteAll();
-    labelHandler.deleteAll();
+    deleteAll();
   }
 
   @Test
@@ -579,9 +572,11 @@ public class TestTaskDAO extends AbstractTest {
 
     coworkers.add("worker2");
     task.setCoworker(coworkers);
+    tDAO.update(task);
+
     //worker2 is now a coworker, so he has permission
     ConversationState.setCurrent(new ConversationState(worker2));
-    Assert.assertEquals(true, TaskUtil.hasEditPermission(taskService,task));
+    Assert.assertEquals(true, TaskUtil.hasEditPermission(taskService, task));
   }
 
   @Test

--- a/services/src/test/java/org/exoplatform/task/security/TestPermission.java
+++ b/services/src/test/java/org/exoplatform/task/security/TestPermission.java
@@ -64,9 +64,7 @@ public class TestPermission extends AbstractTest {
 
   @After
   public void tearDown() {
-    tDAO.deleteAll();
-    daoHandler.getStatusHandler().deleteAll();
-    pDAO.deleteAll();
+    deleteAll();
   }
 
   @Test

--- a/services/src/test/java/org/exoplatform/task/service/TaskStorageTest.java
+++ b/services/src/test/java/org/exoplatform/task/service/TaskStorageTest.java
@@ -89,15 +89,7 @@ public class TaskStorageTest extends AbstractTest {
 
   @After
   public void tearDown() {
-    for (Task t : tDAO.findAll()) {
-      t.setStatus(null);
-    }
-    tDAO.updateAll(tDAO.findAll());
-    daoHandler.getLabelTaskMappingHandler().deleteAll();
-    daoHandler.getTaskLogHandler().deleteAll();
-    cDAO.deleteAll();
-    tDAO.deleteAll();
-    labelHandler.deleteAll();
+    deleteAll();
   }
 
   @Test

--- a/services/src/test/java/org/exoplatform/task/storage/CommentStorageTest.java
+++ b/services/src/test/java/org/exoplatform/task/storage/CommentStorageTest.java
@@ -30,6 +30,7 @@ import org.junit.Test;
 import org.exoplatform.commons.utils.ListAccess;
 import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.container.PortalContainer;
+import org.exoplatform.container.component.RequestLifeCycle;
 import org.exoplatform.task.AbstractTest;
 import org.exoplatform.task.dao.DAOHandler;
 import org.exoplatform.task.dao.TaskHandler;
@@ -65,9 +66,7 @@ public class CommentStorageTest extends AbstractTest {
 
   @After
   public void cleanData() {
-    endRequestLifecycle();
-    commentDAO.deleteAll();
-    taskDAO.deleteAll();
+    deleteAll();
   }
   @Test
   public void testMentionedUsers() throws EntityNotFoundException {


### PR DESCRIPTION
This change will upgrade Hibernate to version 6.6 which introduced a bug fix (as explained in https://discourse.hibernate.org/t/instance-save-transient-before/10293/2) which makes some operations buggy when made in the same transaction. This change ensures to split operations to not hit such a problem.