### PR TITLE
fix: Mustache syntax (double curly braces) in a task comment displays an empty comment - MEED-9327 - Meeds-io/meeds#3439

### DIFF
--- a/webapps/src/main/webapp/vue-app/taskCommentsDrawer/components/TaskCommentItem.vue
+++ b/webapps/src/main/webapp/vue-app/taskCommentsDrawer/components/TaskCommentItem.vue
@@ -50,7 +50,7 @@
       <div class="commentBody d-block overflow-hidden ms-10 mt-1">
         <dynamic-html-element
           v-if="bodyElement"
-          :child="bodyElement"
+          :html="bodyElement"
           class="taskContentComment reset-style-box rich-editor-content"
           dir="auto" />
         <attachments-image-items
@@ -135,9 +135,7 @@ export default {
       return this.getRelativeTime(this.comment.comment.createdTime.time);
     },
     bodyElement() {
-      return this.comment?.formattedComment && {
-        template: ExtendedDomPurify.purify(`<div>${this.comment.formattedComment}</div>`) || '',
-      } || null;
+      return this.comment?.formattedComment || '';
     },
   },
   methods: {

--- a/webapps/src/main/webapp/vue-app/taskCommentsDrawer/components/TaskLastComment.vue
+++ b/webapps/src/main/webapp/vue-app/taskCommentsDrawer/components/TaskLastComment.vue
@@ -34,7 +34,7 @@
     <div class="commentBody d-block overflow-hidden ms-10 mt-1">
       <dynamic-html-element
         v-if="bodyElement"
-        :child="bodyElement"
+        :html="bodyElement"
         class="taskContentComment reset-style-box rich-editor-content"
         dir="auto" />
       <attachments-image-items
@@ -102,9 +102,7 @@ export default {
       return `comment-${this.comment.comment.id}`;
     },
     bodyElement() {
-      return this.comment?.formattedComment && {
-        template: ExtendedDomPurify.purify(`<div>${this.comment.formattedComment}</div>`) || '',
-      } || null;
+      return this.comment?.formattedComment || '';
     },
   },
   methods: {


### PR DESCRIPTION
before this change, when add a comment containing mustache syntax (double curly braces) in a task and check the comment, the typed content isn't displayed as text between double curly braces is considered as vuejs variable that is not defined. To fix this problem, use the html prop instead of child. after this change, the comment is displayed correctly.