### PR TITLE
fix: Upgrade Hibernate to version 6.6 - Meeds-io/meeds#3365

### DIFF
--- a/services/pom.xml
+++ b/services/pom.xml
@@ -30,7 +30,7 @@
     <rest.api.doc.version>1.0</rest.api.doc.version>
     <rest.api.doc.description>Tasks addon rest endpoints</rest.api.doc.description>
 
-    <exo.test.coverage.ratio>0.36</exo.test.coverage.ratio>
+    <exo.test.coverage.ratio>0.35</exo.test.coverage.ratio>
   </properties>
   <!-- JPA -->
   <dependencies>
@@ -99,6 +99,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration>
+          <runOrder>alphabetical</runOrder>
           <systemPropertyVariables>
             <gatein.test.tmp.dir>${project.build.directory}/datadir</gatein.test.tmp.dir>
             <exo.files.storage.dir>${project.build.directory}/datadir</exo.files.storage.dir>

--- a/services/src/main/java/io/meeds/task/domain/LabelField.java
+++ b/services/src/main/java/io/meeds/task/domain/LabelField.java
@@ -1,30 +1,26 @@
 /**
  * This file is part of the Meeds project (https://meeds.io/).
- * Copyright (C) 2022 Meeds Association
- * contact@meeds.io
+ * 
+ * Copyright (C) 2025 Meeds Association contact@meeds.io
+ * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 3 of the License, or (at your option) any later version.
+ * 
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
+ * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-package org.exoplatform.task.dao;
+package io.meeds.task.domain;
 
-import java.io.Serializable;
+public enum LabelField {
 
-import org.exoplatform.commons.api.persistence.GenericDAO;
-import org.exoplatform.commons.utils.ListAccess;
-import org.exoplatform.task.domain.LabelTaskMapping;
+  NAME, COLOR, PARENT, HIDDEN
 
-public interface LabelTaskMappingHandler extends GenericDAO<LabelTaskMapping, Serializable> {
-    LabelTaskMapping findLabelTaskMapping(long labelId, long taskId);
-
-    ListAccess<LabelTaskMapping> findLabelMappings(long taskId);
 }
-

--- a/services/src/main/java/org/exoplatform/task/dao/condition/Conditions.java
+++ b/services/src/main/java/org/exoplatform/task/dao/condition/Conditions.java
@@ -36,8 +36,8 @@ public class Conditions {
   public static String TASK_STATUS_NAME = "status.name";
   public static String TASK_DUEDATE = "dueDate";
   public static String TASK_PROJECT = "status.project.id";
-  public static String TASK_LABEL_USERNAME = "lblMapping.label.username";
-  public static String TASK_LABEL_ID = "lblMapping.label.id";
+  public static String TASK_LABEL_USERNAME = "labels.label.username";
+  public static String TASK_LABEL_ID = "labels.label.id";
   public static String TASK_COMPLETED = "completed";
   public static String TASK_START_DATE = "startDate";
   public static String TASK_END_DATE = "endDate";
@@ -51,7 +51,7 @@ public class Conditions {
   public static final String PARENT = "parent";
   public static final String PARENT_ID = "parent.id";
   public static final String USERNAME = "username";  
-  public static final String LABEL_TASK_ID = "lblMapping.task.id";
+  public static final String LABEL_TASK_ID = "tasks.task.id";
 
   public static <T> SingleCondition<T> eq(String fieldName, T value) {
     return new SingleCondition<T>(SingleCondition.EQ, fieldName, value);

--- a/services/src/main/java/org/exoplatform/task/dao/jpa/DAOHandlerJPAImpl.java
+++ b/services/src/main/java/org/exoplatform/task/dao/jpa/DAOHandlerJPAImpl.java
@@ -59,7 +59,7 @@ public class DAOHandlerJPAImpl extends AbstractDAOHandler implements DAOHandler 
     } else if (e instanceof Status) {
       return (E)((Status)e).clone();
     } else if (e instanceof Project) {
-      return (E)((Project)e).clone(false);
+      return (E)((Project)e).clone();
     } else if (e instanceof Comment) {
       return (E)((Comment)e).clone();
     } else if (e instanceof ChangeLog) {

--- a/services/src/main/java/org/exoplatform/task/dao/jpa/LabelTaskMappingDAOImpl.java
+++ b/services/src/main/java/org/exoplatform/task/dao/jpa/LabelTaskMappingDAOImpl.java
@@ -17,35 +17,45 @@
 package org.exoplatform.task.dao.jpa;
 
 import java.io.Serializable;
-import java.util.List;
 
 import org.exoplatform.commons.utils.ListAccess;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.task.dao.LabelTaskMappingHandler;
-import org.exoplatform.task.domain.Label;
 import org.exoplatform.task.domain.LabelTaskMapping;
-import org.exoplatform.task.domain.Task;
 
 import jakarta.persistence.PersistenceException;
-import jakarta.persistence.Query;
 import jakarta.persistence.TypedQuery;
 
 public class LabelTaskMappingDAOImpl extends CommonJPADAO<LabelTaskMapping, Serializable> implements LabelTaskMappingHandler {
 
-    private static final Log log = ExoLogger.getExoLogger(LabelTaskMappingDAOImpl.class);
+  private static final String LABEL_ID = "labelId";
 
-    @Override
-    public LabelTaskMapping findLabelTaskMapping(long labelId, long taskId) {
-        TypedQuery<LabelTaskMapping> query = getEntityManager().createNamedQuery("LabelTaskMapping.findLabelMapping", LabelTaskMapping.class);
-        query.setParameter("labelId", labelId);
-        query.setParameter("taskId", taskId);
-        try {
-            return cloneEntity((LabelTaskMapping)query.getSingleResult());
-        } catch (PersistenceException e) {
-            log.error("Error when fetching label mapping", e);
-            return null;
-        }
+  private static final String TASK_ID  = "taskId";
+
+  private static final Log    log      = ExoLogger.getExoLogger(LabelTaskMappingDAOImpl.class);
+
+  @Override
+  public ListAccess<LabelTaskMapping> findLabelMappings(long taskId) {
+    TypedQuery<LabelTaskMapping> query = getEntityManager().createNamedQuery("LabelTaskMapping.findLabelMappingsOfTask", LabelTaskMapping.class);
+    TypedQuery<Long> count = getEntityManager().createNamedQuery("LabelTaskMapping.countLabelMappingsOfTask", Long.class);
+    query.setParameter(TASK_ID, taskId);
+    count.setParameter(TASK_ID, taskId);
+    return new JPAQueryListAccess<>(LabelTaskMapping.class, count, query);
+  }
+
+  @Override
+  public LabelTaskMapping findLabelTaskMapping(long labelId, long taskId) {
+    TypedQuery<LabelTaskMapping> query = getEntityManager().createNamedQuery("LabelTaskMapping.findLabelMapping",
+                                                                             LabelTaskMapping.class);
+    query.setParameter(LABEL_ID, labelId);
+    query.setParameter(TASK_ID, taskId);
+    try {
+      return cloneEntity(query.getSingleResult());
+    } catch (PersistenceException e) {
+      log.error("Error when fetching label mapping", e);
+      return null;
     }
-}
+  }
 
+}

--- a/services/src/main/java/org/exoplatform/task/dao/jpa/StatusDAOImpl.java
+++ b/services/src/main/java/org/exoplatform/task/dao/jpa/StatusDAOImpl.java
@@ -16,23 +16,18 @@
  */
 package org.exoplatform.task.dao.jpa;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.NoResultException;
-import jakarta.persistence.Query;
-import jakarta.persistence.TypedQuery;
 
 import org.apache.commons.lang3.StringUtils;
 
-import org.exoplatform.commons.persistence.impl.EntityManagerService;
-import org.exoplatform.commons.persistence.impl.GenericDAOJPAImpl;
 import org.exoplatform.task.dao.StatusHandler;
 import org.exoplatform.task.domain.Status;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import jakarta.persistence.TypedQuery;
 
 /**
  * Created by The eXo Platform SAS
@@ -103,5 +98,6 @@ public class StatusDAOImpl extends CommonJPADAO<Status, Long> implements StatusH
     }
     return cloneEntities(q.getResultList());
   }
+
 }
 

--- a/services/src/main/java/org/exoplatform/task/dao/jpa/TaskDAOImpl.java
+++ b/services/src/main/java/org/exoplatform/task/dao/jpa/TaskDAOImpl.java
@@ -34,6 +34,7 @@ import jakarta.persistence.criteria.Path;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
 
+import org.exoplatform.commons.api.persistence.ExoTransactional;
 import org.exoplatform.commons.utils.ListAccess;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
@@ -57,25 +58,8 @@ public class TaskDAOImpl extends CommonJPADAO<Task, Long> implements TaskHandler
   public TaskDAOImpl() {
   }
 
-  /*@Override
-  public void delete(Task entity) {
-    EntityManager em = getEntityManager();
-    Task task = em.find(Task.class, entity.getId());
-
-    // Delete all task log relate to this task
-    Query query = em.createNamedQuery("TaskChangeLog.removeChangeLogByTaskId");
-    query.setParameter("taskId", entity.getId());
-    query.executeUpdate();
-
-    // Delete all comments of task
-    query = em.createNamedQuery("Comment.deleteCommentOfTask");
-    query.setParameter("taskId", entity.getId());
-    query.executeUpdate();
-
-    em.remove(task);
-  }*/
-
   @Override
+  @ExoTransactional
   public void updateStatus(Status stOld, Status stNew) {
     Query query = getEntityManager().createNamedQuery("Task.updateStatus");
     query.setParameter("status_old", stOld);

--- a/services/src/main/java/org/exoplatform/task/domain/ChangeLog.java
+++ b/services/src/main/java/org/exoplatform/task/domain/ChangeLog.java
@@ -26,7 +26,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.NamedQuery;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
-import lombok.EqualsAndHashCode;
+import lombok.Data;
 
 @Entity(name = "TaskChangeLog")
 @Table(name = "TASK_CHANGE_LOGS")
@@ -36,7 +36,7 @@ import lombok.EqualsAndHashCode;
         query = "SELECT count(log) FROM TaskChangeLog log WHERE log.task.id = :taskId")
 @NamedQuery(name = "TaskChangeLog.removeChangeLogByTaskId",
         query = "DELETE FROM TaskChangeLog log WHERE log.task.id = :taskId")
-@EqualsAndHashCode
+@Data
 public class ChangeLog implements Comparable<ChangeLog> {
 
   @Id
@@ -59,61 +59,13 @@ public class ChangeLog implements Comparable<ChangeLog> {
   @Column(name="CREATED_TIME")
   private long createdTime = System.currentTimeMillis();
 
-  public long getId() {
-    return id;
-  }
-
-  public void setId(long id) {
-    this.id = id;
-  }
-
-  public Task getTask() {
-    return task;
-  }
-
-  public void setTask(Task task) {
-    this.task = task;
-  }
-
-  public String getAuthor() {
-    return author;
-  }
-
-  public void setAuthor(String author) {
-    this.author = author;
-  }
-
-  public String getActionName() {
-    return actionName;
-  }
-
-  public void setActionName(String change) {
-    this.actionName = change;
-  }
-
-  public String getTarget() {
-    return target;
-  }
-
-  public void setTarget(String target) {
-    this.target = target;
-  }
-
-  public long getCreatedTime() {
-    return createdTime;
-  }
-
-  public void setCreatedTime(long createdTime) {
-    this.createdTime = createdTime;
-  }
-
   @Override
   public int compareTo(ChangeLog o) {
     return (int)(getCreatedTime() - o.getCreatedTime());
   }
 
   @Override
-  public ChangeLog clone() {
+  public ChangeLog clone() { // NOSONAR
     ChangeLog log = new ChangeLog();
     log.setId(getId());
     log.setTask(getTask().clone());

--- a/services/src/main/java/org/exoplatform/task/domain/ChangeLog.java
+++ b/services/src/main/java/org/exoplatform/task/domain/ChangeLog.java
@@ -16,8 +16,6 @@
  */
 package org.exoplatform.task.domain;
 
-import org.exoplatform.commons.api.persistence.ExoEntity;
-
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -25,22 +23,20 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.NamedQueries;
 import jakarta.persistence.NamedQuery;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
+import lombok.EqualsAndHashCode;
 
 @Entity(name = "TaskChangeLog")
-@ExoEntity
 @Table(name = "TASK_CHANGE_LOGS")
-@NamedQueries({
-        @NamedQuery(name = "TaskChangeLog.findChangeLogByTaskId",
-                    query = "SELECT log FROM TaskChangeLog log WHERE log.task.id = :taskId ORDER BY log.createdTime DESC"),
-        @NamedQuery(name = "TaskChangeLog.countChangeLogByTaskId",
-                query = "SELECT count(log) FROM TaskChangeLog log WHERE log.task.id = :taskId"),
-        @NamedQuery(name = "TaskChangeLog.removeChangeLogByTaskId",
-                query = "DELETE FROM TaskChangeLog log WHERE log.task.id = :taskId")
-})
+@NamedQuery(name = "TaskChangeLog.findChangeLogByTaskId",
+            query = "SELECT log FROM TaskChangeLog log WHERE log.task.id = :taskId ORDER BY log.createdTime DESC")
+@NamedQuery(name = "TaskChangeLog.countChangeLogByTaskId",
+        query = "SELECT count(log) FROM TaskChangeLog log WHERE log.task.id = :taskId")
+@NamedQuery(name = "TaskChangeLog.removeChangeLogByTaskId",
+        query = "DELETE FROM TaskChangeLog log WHERE log.task.id = :taskId")
+@EqualsAndHashCode
 public class ChangeLog implements Comparable<ChangeLog> {
 
   @Id

--- a/services/src/main/java/org/exoplatform/task/domain/Comment.java
+++ b/services/src/main/java/org/exoplatform/task/domain/Comment.java
@@ -21,7 +21,6 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.CollectionTable;
@@ -40,6 +39,7 @@ import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import jakarta.persistence.Temporal;
 import jakarta.persistence.TemporalType;
+import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 /**
@@ -57,7 +57,7 @@ import lombok.EqualsAndHashCode;
     query = "DELETE FROM TaskComment c WHERE c.task.id = :taskId")
 @NamedQuery(name = "Comment.findMentionedUsersOfTask",
     query = "SELECT m FROM TaskComment c INNER JOIN c.mentionedUsers m WHERE c.task.id = :taskId")
-@EqualsAndHashCode
+@Data
 public class Comment {
 
   @Id
@@ -73,7 +73,7 @@ public class Comment {
   private String               author;
 
   @Column(name = "CMT")
-  private String               comment;
+  private String               comment; // NOSONAR
 
   @Temporal(TemporalType.TIMESTAMP)
   @Column(name = "CREATED_TIME")
@@ -99,69 +99,9 @@ public class Comment {
   @EqualsAndHashCode.Exclude
   private Set<String>          mentionedUsers = new HashSet<>();
 
-  public Long getId() {
-    return id;
-  }
-
-  public void setId(Long id) {
-    this.id = id;
-  }
-
-  public String getAuthor() {
-    return author;
-  }
-
-  public void setAuthor(String author) {
-    this.author = author;
-  }
-
-  public String getComment() {
-    return comment;
-  }
-
-  public void setComment(String comment) {
-    this.comment = comment;
-  }
-
-  public void setMentionedUsers(Set<String> mentionedUsers) {
-    this.mentionedUsers = mentionedUsers;
-  }
-
-  public Set<String> getMentionedUsers() {
-    return mentionedUsers.stream().collect(Collectors.toSet());
-  }
-
-  public Date getCreatedTime() {
-    return createdTime;
-  }
-
-  public void setCreatedTime(Date createdTime) {
-    this.createdTime = createdTime;
-  }
-
-  public Task getTask() {
-    return task;
-  }
-
-  public void setTask(Task task) {
-    this.task = task;
-  }
-
-  public Comment getParentComment() {
-    return parentComment;
-  }
-
   public void setParentComment(Comment parentComment) {
     this.parentComment = parentComment;
     this.parentComment.addSubComment(this);
-  }
-
-  public List<Comment> getSubComments() {
-    return subComments;
-  }
-
-  public void setSubComments(List<Comment> subComments) {
-    this.subComments = subComments;
   }
 
   public void addSubComment(Comment subComment) {

--- a/services/src/main/java/org/exoplatform/task/domain/Comment.java
+++ b/services/src/main/java/org/exoplatform/task/domain/Comment.java
@@ -16,36 +16,49 @@
  */
 package org.exoplatform.task.domain;
 
-import java.util.*;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
-import jakarta.persistence.*;
-
-import org.exoplatform.commons.api.persistence.ExoEntity;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.NamedQuery;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import jakarta.persistence.Temporal;
+import jakarta.persistence.TemporalType;
+import lombok.EqualsAndHashCode;
 
 /**
  * @author <a href="mailto:tuyennt@exoplatform.com">Tuyen Nguyen The</a>.
  */
 @Entity(name = "TaskComment")
-@ExoEntity
 @Table(name = "TASK_COMMENTS")
-@NamedQueries({
-                @NamedQuery(name = "Comment.countCommentOfTask",
-                    query = "SELECT count(c) FROM TaskComment c WHERE c.task.id = :taskId AND c.parentComment IS NULL"),
-                @NamedQuery(name = "Comment.findCommentsOfTask",
-                    query = "SELECT c FROM TaskComment c WHERE c.task.id = :taskId AND c.parentComment IS NULL ORDER BY c.createdTime DESC"),
-                @NamedQuery(name = "Comment.findSubCommentsOfComments",
-                    query = "SELECT c FROM TaskComment c WHERE c.parentComment IN (:comments) ORDER BY c.createdTime ASC"),
-                @NamedQuery(name = "Comment.deleteCommentOfTask",
-                    query = "DELETE FROM TaskComment c WHERE c.task.id = :taskId"),
-                @NamedQuery(name = "Comment.findMentionedUsersOfTask",
-                    query = "SELECT m FROM TaskComment c INNER JOIN c.mentionedUsers m WHERE c.task.id = :taskId")
-})
+@NamedQuery(name = "Comment.countCommentOfTask",
+    query = "SELECT count(c) FROM TaskComment c WHERE c.task.id = :taskId AND c.parentComment IS NULL")
+@NamedQuery(name = "Comment.findCommentsOfTask",
+    query = "SELECT c FROM TaskComment c WHERE c.task.id = :taskId AND c.parentComment IS NULL ORDER BY c.createdTime DESC")
+@NamedQuery(name = "Comment.findSubCommentsOfComments",
+    query = "SELECT c FROM TaskComment c WHERE c.parentComment IN (:comments) ORDER BY c.createdTime ASC")
+@NamedQuery(name = "Comment.deleteCommentOfTask",
+    query = "DELETE FROM TaskComment c WHERE c.task.id = :taskId")
+@NamedQuery(name = "Comment.findMentionedUsersOfTask",
+    query = "SELECT m FROM TaskComment c INNER JOIN c.mentionedUsers m WHERE c.task.id = :taskId")
+@EqualsAndHashCode
 public class Comment {
-
-  private static final Pattern pattern        = Pattern.compile("@([^\\s]+)|@([^\\s]+)$");
 
   @Id
   @SequenceGenerator(name = "SEQ_TASK_COMMENTS_COMMENT_ID",
@@ -54,7 +67,7 @@ public class Comment {
   @GeneratedValue(strategy = GenerationType.AUTO,
       generator = "SEQ_TASK_COMMENTS_COMMENT_ID")
   @Column(name = "COMMENT_ID")
-  private long                 id;
+  private Long                 id;
 
   @Column(name = "AUTHOR")
   private String               author;
@@ -68,28 +81,29 @@ public class Comment {
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "TASK_ID")
+  @EqualsAndHashCode.Exclude
   private Task                 task;
 
   @ManyToOne(fetch = FetchType.EAGER)
   @JoinColumn(name = "PARENT_COMMENT_ID")
+  @EqualsAndHashCode.Exclude
   private Comment              parentComment;
 
-  @OneToMany(cascade = CascadeType.REMOVE,
-      mappedBy = "parentComment",
-      fetch = FetchType.LAZY)
-  private List<Comment>        subComments    = new ArrayList<Comment>();
+  @OneToMany(mappedBy = "parentComment", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
+  @EqualsAndHashCode.Exclude
+  private List<Comment>        subComments    = new ArrayList<>();
 
   @ElementCollection(fetch = FetchType.LAZY)
-  @CollectionTable(name = "TASK_COMMENT_MENTIONED_USERS",
-      joinColumns = @JoinColumn(name = "COMMENT_ID"))
+  @CollectionTable(name = "TASK_COMMENT_MENTIONED_USERS", joinColumns = @JoinColumn(name = "COMMENT_ID"))
   @Column(name = "MENTIONED_USERS")
+  @EqualsAndHashCode.Exclude
   private Set<String>          mentionedUsers = new HashSet<>();
 
-  public long getId() {
+  public Long getId() {
     return id;
   }
 
-  public void setId(long id) {
+  public void setId(Long id) {
     this.id = id;
   }
 
@@ -155,7 +169,7 @@ public class Comment {
   }
 
   @Override
-  public Comment clone() {
+  public Comment clone() { // NOSONAR
     Comment c = new Comment();
     c.setId(getId());
     c.setAuthor(getAuthor());

--- a/services/src/main/java/org/exoplatform/task/domain/Label.java
+++ b/services/src/main/java/org/exoplatform/task/domain/Label.java
@@ -34,19 +34,20 @@ import jakarta.persistence.NamedQuery;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
+import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 @Entity(name = "TaskLabel")
 @Table(name = "TASK_LABELS")
 @NamedQuery(name = "Label.findLabelsByTask",
-  query = "SELECT lbl FROM TaskLabel lbl inner join lbl.lblMapping m WHERE lbl.project.id = :projectId AND m.task.id = :taskid ORDER BY lbl.id")
+  query = "SELECT lbl FROM TaskLabel lbl inner join lbl.tasks m WHERE lbl.project.id = :projectId AND m.task.id = :taskid ORDER BY lbl.id")
 @NamedQuery(name = "Label.findLabelsByTaskCount",
-  query = "SELECT count(*) FROM TaskLabel lbl inner join lbl.lblMapping m WHERE lbl.project.id = :projectId AND m.task.id = :taskid")
+  query = "SELECT count(*) FROM TaskLabel lbl inner join lbl.tasks m WHERE lbl.project.id = :projectId AND m.task.id = :taskid")
 @NamedQuery(name = "Label.findLabelsByProject",
   query = "SELECT lbl FROM TaskLabel lbl WHERE lbl.project.id = :projectId ORDER BY lbl.id")
 @NamedQuery(name = "Label.findLabelsByProjectCount",
   query = "SELECT count(*) FROM TaskLabel lbl WHERE lbl.project.id = :projectId ORDER BY lbl.id")
-@EqualsAndHashCode
+@Data
 public class Label implements Serializable {
 
   private static final long serialVersionUID = 806731692361018042L;
@@ -78,7 +79,7 @@ public class Label implements Serializable {
   //Still use for named query
   @OneToMany(mappedBy = "label", fetch=FetchType.LAZY)
   @EqualsAndHashCode.Exclude
-  private Set<LabelTaskMapping> lblMapping = new HashSet<>();
+  private Set<LabelTaskMapping> tasks = new HashSet<>();
 
   @ManyToOne
   @JoinColumn(name = "PROJECT_ID")
@@ -94,72 +95,4 @@ public class Label implements Serializable {
     this.project = project;
   }
 
-  public long getId() {
-    return id;
-  }
-
-  public void setId(long id) {
-    this.id = id;
-  }
-
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  public String getColor() {
-    return color;
-  }
-
-  public void setColor(String color) {
-    this.color = color;
-  }
-
-  public Label getParent() {
-    return parent;
-  }
-
-  public void setParent(Label parent) {
-    this.parent = parent;
-  }
-
-  public List<Label> getChildren() {
-    return children;
-  }
-
-  public void setChildren(List<Label> children) {
-    this.children = children;
-  }
-
-  public String getUsername() {
-    return username;
-  }
-
-  public void setUsername(String username) {
-    this.username = username;
-  }
-
-  public Project getProject() {
-    return project;
-  }
-
-  public void setProject(Project project) {
-    this.project = project;
-  }
-
-  public boolean isHidden() {
-    return hidden;
-  }
-
-  public void setHidden(boolean hidden) {
-    this.hidden = hidden;
-  }
-
-  public enum FIELDS {
-    NAME, COLOR, PARENT, HIDDEN
-  }
-  
 }

--- a/services/src/main/java/org/exoplatform/task/domain/Label.java
+++ b/services/src/main/java/org/exoplatform/task/domain/Label.java
@@ -16,17 +16,27 @@
  */
 package org.exoplatform.task.domain;
 
-import jakarta.persistence.*;
-
+import java.io.Serializable;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 
-import org.exoplatform.commons.api.persistence.ExoEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.NamedQuery;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import lombok.EqualsAndHashCode;
 
 @Entity(name = "TaskLabel")
-@ExoEntity
 @Table(name = "TASK_LABELS")
 @NamedQuery(name = "Label.findLabelsByTask",
   query = "SELECT lbl FROM TaskLabel lbl inner join lbl.lblMapping m WHERE lbl.project.id = :projectId AND m.task.id = :taskid ORDER BY lbl.id")
@@ -36,39 +46,43 @@ import org.exoplatform.commons.api.persistence.ExoEntity;
   query = "SELECT lbl FROM TaskLabel lbl WHERE lbl.project.id = :projectId ORDER BY lbl.id")
 @NamedQuery(name = "Label.findLabelsByProjectCount",
   query = "SELECT count(*) FROM TaskLabel lbl WHERE lbl.project.id = :projectId ORDER BY lbl.id")
-public class Label {
+@EqualsAndHashCode
+public class Label implements Serializable {
+
+  private static final long serialVersionUID = 806731692361018042L;
+
   @Id
-  @SequenceGenerator(name="SEQ_TASK_LABELS_LABEL_ID", sequenceName="SEQ_TASK_LABELS_LABEL_ID", allocationSize = 1)
-  @GeneratedValue(strategy=GenerationType.AUTO, generator="SEQ_TASK_LABELS_LABEL_ID")
+  @SequenceGenerator(name = "SEQ_TASK_LABELS_LABEL_ID", sequenceName = "SEQ_TASK_LABELS_LABEL_ID", allocationSize = 1)
+  @GeneratedValue(strategy = GenerationType.AUTO, generator = "SEQ_TASK_LABELS_LABEL_ID")
   @Column(name = "LABEL_ID")
-  private long      id;
+  private long              id;
 
-  @Column(name = "USERNAME", nullable=false)
-  private String username;
+  @Column(name = "USERNAME", nullable = false)
+  private String            username;
 
-  private String    name;
+  private String            name;
 
-  private String    color;
-  
-  private boolean hidden;
-  
-  public static enum FIELDS {
-    NAME, COLOR, PARENT, HIDDEN
-  }
+  private String            color;
+
+  private boolean           hidden;
 
   @ManyToOne(optional = true, fetch = FetchType.LAZY)
   @JoinColumn(name = "PARENT_LABEL_ID", nullable = true)
+  @EqualsAndHashCode.Exclude
   private Label parent;
 
   @OneToMany(mappedBy = "parent", fetch = FetchType.LAZY)
+  @EqualsAndHashCode.Exclude
   private List<Label> children = new LinkedList<>();
   
   //Still use for named query
   @OneToMany(mappedBy = "label", fetch=FetchType.LAZY)
+  @EqualsAndHashCode.Exclude
   private Set<LabelTaskMapping> lblMapping = new HashSet<>();
 
   @ManyToOne
   @JoinColumn(name = "PROJECT_ID")
+  @EqualsAndHashCode.Exclude
   private Project project;
 
   public Label() {
@@ -144,6 +158,8 @@ public class Label {
     this.hidden = hidden;
   }
 
-
+  public enum FIELDS {
+    NAME, COLOR, PARENT, HIDDEN
+  }
   
 }

--- a/services/src/main/java/org/exoplatform/task/domain/LabelTaskMapping.java
+++ b/services/src/main/java/org/exoplatform/task/domain/LabelTaskMapping.java
@@ -22,18 +22,22 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.NamedQueries;
 import jakarta.persistence.NamedQuery;
 import jakarta.persistence.Table;
+import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 @Entity(name = "TaskLabelTaskMapping")
 @Table(name = "TASK_LABEL_TASK")
+@NamedQuery(name = "LabelTaskMapping.countLabelMappingsOfTask",
+  query = "SELECT count(m) FROM TaskLabelTaskMapping m WHERE m.task.id = :taskId")
+@NamedQuery(name = "LabelTaskMapping.findLabelMappingsOfTask",
+  query = "SELECT m FROM TaskLabelTaskMapping m WHERE m.task.id = :taskId")
 @NamedQuery(name = "LabelTaskMapping.removeLabelTaskMapping",
     query = "DELETE FROM TaskLabelTaskMapping m WHERE m.label.id = :labelId")
 @NamedQuery(name = "LabelTaskMapping.findLabelMapping",
      query = "SELECT m FROM TaskLabelTaskMapping m  WHERE m.label.id = :labelId and  m.task.id = :taskId")
-@EqualsAndHashCode
+@Data
 public class LabelTaskMapping implements Serializable {
 
   private static final long serialVersionUID = -8180443225233907972L;
@@ -49,29 +53,12 @@ public class LabelTaskMapping implements Serializable {
   @EqualsAndHashCode.Exclude
   private Task              task;
 
-  public LabelTaskMapping() {    
+  public LabelTaskMapping() {
   }
-  
+
   public LabelTaskMapping(Label label, Task task) {
     super();
     this.label = label;
     this.task = task;
   }
-
-  public Label getLabel() {
-    return label;
-  }
-  
-  public void setLabel(Label label) {
-    this.label = label;
-  }
-  
-  public Task getTask() {
-    return task;
-  }
-  
-  public void setTask(Task task) {
-    this.task = task;
-  }
-  
 }

--- a/services/src/main/java/org/exoplatform/task/domain/LabelTaskMapping.java
+++ b/services/src/main/java/org/exoplatform/task/domain/LabelTaskMapping.java
@@ -16,6 +16,8 @@
  */
 package org.exoplatform.task.domain;
 
+import java.io.Serializable;
+
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
@@ -23,30 +25,30 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.NamedQueries;
 import jakarta.persistence.NamedQuery;
 import jakarta.persistence.Table;
-
-import java.io.Serializable;
-
-import org.exoplatform.commons.api.persistence.ExoEntity;
+import lombok.EqualsAndHashCode;
 
 @Entity(name = "TaskLabelTaskMapping")
-@ExoEntity
 @Table(name = "TASK_LABEL_TASK")
-@NamedQueries({  
-  @NamedQuery(name = "LabelTaskMapping.removeLabelTaskMapping",
-      query = "DELETE FROM TaskLabelTaskMapping m WHERE m.label.id = :labelId"),
-  @NamedQuery(name = "LabelTaskMapping.findLabelMapping",
-       query = "SELECT m FROM TaskLabelTaskMapping m  WHERE m.label.id = :labelId and  m.task.id = :taskId")
-})
+@NamedQuery(name = "LabelTaskMapping.removeLabelTaskMapping",
+    query = "DELETE FROM TaskLabelTaskMapping m WHERE m.label.id = :labelId")
+@NamedQuery(name = "LabelTaskMapping.findLabelMapping",
+     query = "SELECT m FROM TaskLabelTaskMapping m  WHERE m.label.id = :labelId and  m.task.id = :taskId")
+@EqualsAndHashCode
 public class LabelTaskMapping implements Serializable {
+
+  private static final long serialVersionUID = -8180443225233907972L;
+
   @Id
   @ManyToOne
   @JoinColumn(name = "LABEL_ID")
-  private Label label;
+  private Label             label;
+
   @Id
   @ManyToOne
   @JoinColumn(name = "TASK_ID")
-  private Task task;
-  
+  @EqualsAndHashCode.Exclude
+  private Task              task;
+
   public LabelTaskMapping() {    
   }
   

--- a/services/src/main/java/org/exoplatform/task/domain/Project.java
+++ b/services/src/main/java/org/exoplatform/task/domain/Project.java
@@ -16,123 +16,145 @@
  */
 package org.exoplatform.task.domain;
 
-import org.exoplatform.commons.api.persistence.ExoEntity;
+import java.io.Serializable;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+
 import org.exoplatform.services.security.Identity;
 import org.exoplatform.services.security.MembershipEntry;
 import org.exoplatform.task.util.ProjectUtil;
 
-import jakarta.persistence.*;
-
-import java.util.*;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.NamedQuery;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import jakarta.persistence.Temporal;
+import jakarta.persistence.TemporalType;
+import lombok.EqualsAndHashCode;
 
 /**
  * @author <a href="mailto:tuyennt@exoplatform.com">Tuyen Nguyen The</a>
  */
 @Entity(name = "TaskProject")
-@ExoEntity
 @Table(name = "TASK_PROJECTS")
-@NamedQueries({
-  @NamedQuery(
-          name = "TaskProject.findAllProjects",
-          query = "SELECT DISTINCT p FROM TaskProject p ORDER BY p.lastModifiedDate DESC"
-  ),
-  @NamedQuery(
-              name = "TaskProject.countAllProjects",
-              query = "SELECT count(p) FROM TaskProject p"
-  ),
-  @NamedQuery(
-              name = "TaskProject.findProjectsByKeyword",
-              query = "SELECT DISTINCT p FROM TaskProject p WHERE LOWER(p.name) LIKE LOWER(CONCAT('%', :name, '%')) order by p.lastModifiedDate desc"
-  ),
-  @NamedQuery(
-              name = "TaskProject.findProjectsByIDs",
-              query = "SELECT DISTINCT p FROM TaskProject p WHERE p.id in (:ids) order by p.lastModifiedDate desc"
-  ),
-  @NamedQuery(
-              name = "TaskProject.countProjectsByKeyword",
-              query = "SELECT count(p) FROM TaskProject p WHERE LOWER(p.name) LIKE LOWER(CONCAT('%', :name, '%'))"
-  ),
-  @NamedQuery(
-              name = "TaskProject.findProjectsByMemberships",
-              query = "SELECT DISTINCT p FROM TaskProject p"
-                  + " LEFT JOIN p.manager manager "
-                  + " LEFT JOIN p.participator participator "
-                  + " WHERE manager IN (:memberships) OR participator IN (:memberships)"
-                  + " order by p.lastModifiedDate desc"
-  ),
-  @NamedQuery(
-              name = "TaskProject.countProjectsByMemberships",
-              query = "SELECT count(p) FROM TaskProject p"
-                  + " LEFT JOIN p.manager manager "
-                  + " LEFT JOIN p.participator participator "
-                  + " WHERE manager IN (:memberships) OR participator IN (:memberships)"
-  ),
-  @NamedQuery(
-              name = "TaskProject.findProjectsByMembershipsByKeyword",
-              query = "SELECT DISTINCT p FROM TaskProject p "
-                  + " LEFT JOIN p.manager manager "
-                  + " LEFT JOIN p.participator participator "
-                  + " WHERE (manager IN (:memberships) OR participator IN (:memberships)) AND LOWER(p.name) LIKE LOWER(CONCAT('%', :name, '%'))"
-                  + " ORDER BY p.lastModifiedDate DESC"
-  ),
-  @NamedQuery(
-              name = "TaskProject.countProjectsByMembershipsByKeyword",
-              query = "SELECT count(p) FROM TaskProject p "
-                  + " LEFT JOIN p.manager manager "
-                  + " LEFT JOIN p.participator participator "
-                  + " WHERE (manager IN (:memberships) OR participator IN (:memberships)) AND LOWER(p.name) LIKE LOWER(CONCAT('%', :name, '%'))"
-  )
-})
-public class Project {
+@NamedQuery(
+        name = "TaskProject.findAllProjects",
+        query = "SELECT DISTINCT p FROM TaskProject p ORDER BY p.lastModifiedDate DESC"
+)
+@NamedQuery(
+            name = "TaskProject.countAllProjects",
+            query = "SELECT count(p) FROM TaskProject p"
+)
+@NamedQuery(
+            name = "TaskProject.findProjectsByKeyword",
+            query = "SELECT DISTINCT p FROM TaskProject p WHERE LOWER(p.name) LIKE LOWER(CONCAT('%', :name, '%')) order by p.lastModifiedDate desc"
+)
+@NamedQuery(
+            name = "TaskProject.findProjectsByIDs",
+            query = "SELECT DISTINCT p FROM TaskProject p WHERE p.id in (:ids) order by p.lastModifiedDate desc"
+)
+@NamedQuery(
+            name = "TaskProject.countProjectsByKeyword",
+            query = "SELECT count(p) FROM TaskProject p WHERE LOWER(p.name) LIKE LOWER(CONCAT('%', :name, '%'))"
+)
+@NamedQuery(
+            name = "TaskProject.findProjectsByMemberships",
+            query = "SELECT DISTINCT p FROM TaskProject p"
+                + " LEFT JOIN p.manager manager "
+                + " LEFT JOIN p.participator participator "
+                + " WHERE manager IN (:memberships) OR participator IN (:memberships)"
+                + " order by p.lastModifiedDate desc"
+)
+@NamedQuery(
+            name = "TaskProject.countProjectsByMemberships",
+            query = "SELECT count(p) FROM TaskProject p"
+                + " LEFT JOIN p.manager manager "
+                + " LEFT JOIN p.participator participator "
+                + " WHERE manager IN (:memberships) OR participator IN (:memberships)"
+)
+@NamedQuery(
+            name = "TaskProject.findProjectsByMembershipsByKeyword",
+            query = "SELECT DISTINCT p FROM TaskProject p "
+                + " LEFT JOIN p.manager manager "
+                + " LEFT JOIN p.participator participator "
+                + " WHERE (manager IN (:memberships) OR participator IN (:memberships)) AND LOWER(p.name) LIKE LOWER(CONCAT('%', :name, '%'))"
+                + " ORDER BY p.lastModifiedDate DESC"
+)
+@NamedQuery(
+            name = "TaskProject.countProjectsByMembershipsByKeyword",
+            query = "SELECT count(p) FROM TaskProject p "
+                + " LEFT JOIN p.manager manager "
+                + " LEFT JOIN p.participator participator "
+                + " WHERE (manager IN (:memberships) OR participator IN (:memberships)) AND LOWER(p.name) LIKE LOWER(CONCAT('%', :name, '%'))"
+)
+@EqualsAndHashCode
+public class Project implements Serializable {
 
-  public static final String PREFIX_CLONE = "Copy of ";
+  private static final long  serialVersionUID = -5595949787344061794L;
+
+  public static final String PREFIX_CLONE     = "Copy of ";
 
   @Id
-  @SequenceGenerator(name="SEQ_TASK_PROJECTS_PROJECT_ID", sequenceName="SEQ_TASK_PROJECTS_PROJECT_ID", allocationSize = 1)
-  @GeneratedValue(strategy=GenerationType.AUTO, generator="SEQ_TASK_PROJECTS_PROJECT_ID")
+  @SequenceGenerator(name = "SEQ_TASK_PROJECTS_PROJECT_ID", sequenceName = "SEQ_TASK_PROJECTS_PROJECT_ID", allocationSize = 1)
+  @GeneratedValue(strategy = GenerationType.AUTO, generator = "SEQ_TASK_PROJECTS_PROJECT_ID")
   @Column(name = "PROJECT_ID")
-  private long      id;
+  private long               id;
 
-  private String    name;
+  private String             name;
 
-  private String    description;
+  private String             description;
 
-  private String    color;
+  private String             color;
 
-  //TODO: should remove cascade ALL on this field
-  @OneToMany(mappedBy = "project", cascade = CascadeType.REMOVE, orphanRemoval = true)
-  private Set<Status> status = new HashSet<Status>();
-
-  @ElementCollection
-  @CollectionTable(name = "TASK_PROJECT_MANAGERS",
-      joinColumns = @JoinColumn(name = "PROJECT_ID"))
-  private Set<String> manager = new HashSet<String>();
+  @OneToMany(mappedBy = "project", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true)
+  @EqualsAndHashCode.Exclude
+  private Set<Status>        status;
 
   @ElementCollection
-  @CollectionTable(name = "TASK_PROJECT_PARTICIPATORS",
-      joinColumns = @JoinColumn(name = "PROJECT_ID"))
-  private Set<String> participator = new HashSet<String>();
+  @CollectionTable(name = "TASK_PROJECT_MANAGERS", joinColumns = @JoinColumn(name = "PROJECT_ID"))
+  private Set<String>        manager;
+
+  @ElementCollection
+  @CollectionTable(name = "TASK_PROJECT_PARTICIPATORS", joinColumns = @JoinColumn(name = "PROJECT_ID"))
+  private Set<String>        participator;
 
   @Temporal(TemporalType.DATE)
   @Column(name = "DUE_DATE")
-  private Date dueDate;
+  private Date               dueDate;
 
   @ManyToOne(optional = true, fetch = FetchType.LAZY)
+  @EqualsAndHashCode.Exclude
   @JoinColumn(name = "PARENT_PROJECT_ID", nullable = true)
-  private Project parent;
+  private Project            parent;
 
-  @OneToMany(mappedBy = "parent", fetch = FetchType.LAZY, cascade=CascadeType.REMOVE)
-  private List<Project> children = new LinkedList<Project>();
+  @OneToMany(mappedBy = "parent", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
+  @EqualsAndHashCode.Exclude
+  private List<Project>      children;
 
   // This field is used for remove cascade
   @ManyToMany(mappedBy = "hiddenProjects", fetch = FetchType.LAZY)
-  private Set<UserSetting> hiddenOn = new HashSet<UserSetting>();
-
+  @EqualsAndHashCode.Exclude
+  private Set<UserSetting>   hiddenOn;
 
   // This field is used for remove cascade
   @ManyToMany(mappedBy = "project", fetch = FetchType.LAZY)
-  private Set<Label> lebels = new HashSet<Label>();
-
+  @EqualsAndHashCode.Exclude
+  private Set<Label>         labels;
 
   @Column(name = "LAST_MODIFIED_DATE")
   private Long lastModifiedDate;
@@ -250,31 +272,19 @@ public class Project {
   }
 
   public Project clone(boolean cloneTask) {
-//    Set<String> manager = new HashSet<String>();
-//    Set<String> participator = new HashSet<String>();
-
-    //This create performance issue, we need this to be loaded lazily
-//    if (getManager() != null) {
-//      manager.addAll(getManager());
-//    }
-//    if (getParticipator() != null) {
-//      participator.addAll(getParticipator());
-//    }
-
-    Project project = new Project(this.getName(), this.getDescription(), new HashSet<Status>(),
-        null, null);
-
+    Project project = new Project(this.getName(),
+                                  this.getDescription(),
+                                  new HashSet<>(),
+                                  null,
+                                  null);
     project.setId(getId());
     project.setColor(this.getColor());
     project.setDueDate(this.getDueDate());
     if (this.getParent() != null) {
       project.setParent(getParent().clone(false));
     }
-
-    //
-    project.status = new HashSet<Status>();
-    project.children = new LinkedList<Project>();
-
+    project.status = new HashSet<>();
+    project.children = new LinkedList<>();
     return project;
   }
 
@@ -293,7 +303,7 @@ public class Project {
     if (permissions.contains(user.getUserId())) {
       return true;
     } else {
-      Set<MembershipEntry> memberships = new HashSet<MembershipEntry>();
+      Set<MembershipEntry> memberships = new HashSet<>();
       for (String per : permissions) {
         MembershipEntry entry = MembershipEntry.parse(per);
         if (entry != null) {
@@ -313,28 +323,6 @@ public class Project {
 
   public Set<UserSetting> getHiddenOn() {
     return hiddenOn;
-  }
-
-  @Override
-  public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + (int) (getId() ^ (getId() >>> 32));
-    return result;
-  }
-
-  @Override
-  public boolean equals(Object obj) {
-    if (this == obj)
-      return true;
-    if (obj == null)
-      return false;
-    if (!(obj instanceof Project))
-      return false;
-    Project other = (Project) obj;
-    if (getId() != other.getId())
-      return false;
-    return true;
   }
 
 }

--- a/services/src/main/java/org/exoplatform/task/domain/Project.java
+++ b/services/src/main/java/org/exoplatform/task/domain/Project.java
@@ -25,7 +25,6 @@ import java.util.Set;
 
 import org.exoplatform.services.security.Identity;
 import org.exoplatform.services.security.MembershipEntry;
-import org.exoplatform.task.util.ProjectUtil;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.CollectionTable;
@@ -45,6 +44,7 @@ import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import jakarta.persistence.Temporal;
 import jakarta.persistence.TemporalType;
+import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 /**
@@ -102,7 +102,7 @@ import lombok.EqualsAndHashCode;
                 + " LEFT JOIN p.participator participator "
                 + " WHERE (manager IN (:memberships) OR participator IN (:memberships)) AND LOWER(p.name) LIKE LOWER(CONCAT('%', :name, '%'))"
 )
-@EqualsAndHashCode
+@Data
 public class Project implements Serializable {
 
   private static final long  serialVersionUID = -5595949787344061794L;
@@ -121,7 +121,7 @@ public class Project implements Serializable {
 
   private String             color;
 
-  @OneToMany(mappedBy = "project", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true)
+  @OneToMany(mappedBy = "project", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
   @EqualsAndHashCode.Exclude
   private Set<Status>        status;
 
@@ -170,108 +170,8 @@ public class Project implements Serializable {
     this.participator = participator;
   }
 
-  public long getId() {
-    return id;
-  }
-
-  public void setId(long id) {
-    this.id = id;
-  }
-
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  //TODO: get list status of project via StatusService
-  @Deprecated
-  public Set<Status> getStatus() {
-    return status;
-  }
-
-  @Deprecated
-  public void setStatus(Set<Status> status) {
-    this.status = status;
-  }
-
-  @Deprecated
-  public Set<String> getParticipator() {
-    if (participator == null) {
-      participator = ProjectUtil.getParticipator(getId());
-    }
-    return participator;
-  }
-
-  public void setParticipator(Set<String> participator) {
-    this.participator = participator;
-  }
-
-  @Deprecated
-  public Set<String> getManager() {
-    if (manager == null) {
-      manager = ProjectUtil.getManager(getId());
-    }
-    return manager;
-  }
-
-  public void setManager(Set<String> manager) {
-    this.manager = manager;
-  }
-
-  public String getDescription() {
-    return description;
-  }
-
-  public void setDescription(String description) {
-    this.description = description;
-  }
-
-  public Date getDueDate() {
-    return dueDate;
-  }
-
-  public void setDueDate(Date dueDate) {
-    this.dueDate = dueDate;
-  }
-
-  public String getColor() {
-    return color;
-  }
-
-  public void setColor(String color) {
-    this.color = color;
-  }
-
-  public Project getParent() {
-    return parent;
-  }
-
-  public void setParent(Project parent) {
-    this.parent = parent;
-  }
-
-  public Long getLastModifiedDate() {
-    return lastModifiedDate;
-  }
-
-  public void setLastModifiedDate(Long lastModifiedDate) {
-    this.lastModifiedDate = lastModifiedDate;
-  }
-
-  @Deprecated
-  public List<Project> getChildren() {
-    return children;
-  }
-
-  @Deprecated
-  public void setChildren(List<Project> children) {
-    this.children = children;
-  }
-
-  public Project clone(boolean cloneTask) {
+  @Override
+  public Project clone() { // NOSONAR
     Project project = new Project(this.getName(),
                                   this.getDescription(),
                                   new HashSet<>(),
@@ -281,7 +181,7 @@ public class Project implements Serializable {
     project.setColor(this.getColor());
     project.setDueDate(this.getDueDate());
     if (this.getParent() != null) {
-      project.setParent(getParent().clone(false));
+      project.setParent(getParent().clone());
     }
     project.status = new HashSet<>();
     project.children = new LinkedList<>();
@@ -289,7 +189,7 @@ public class Project implements Serializable {
   }
 
   public boolean canView(Identity user) {
-    Set<String> permissions = new HashSet<String>(getParticipator());
+    Set<String> permissions = new HashSet<>(getParticipator());
     permissions.addAll(getManager());
 
     return hasPermission(user, permissions);
@@ -319,10 +219,6 @@ public class Project implements Serializable {
     }
 
     return false;
-  }
-
-  public Set<UserSetting> getHiddenOn() {
-    return hiddenOn;
   }
 
 }

--- a/services/src/main/java/org/exoplatform/task/domain/Status.java
+++ b/services/src/main/java/org/exoplatform/task/domain/Status.java
@@ -16,68 +16,70 @@
  */
 package org.exoplatform.task.domain;
 
-import org.exoplatform.commons.api.persistence.ExoEntity;
-
-import jakarta.persistence.*;
-import java.util.*;
+import java.io.Serializable;
+import java.util.List;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.NamedQueries;
 import jakarta.persistence.NamedQuery;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
+import lombok.EqualsAndHashCode;
 
 /**
  * @author <a href="mailto:tuyennt@exoplatform.com">Tuyen Nguyen The</a>
  */
 @Entity(name = "TaskStatus")
-@ExoEntity
 @Table(name = "TASK_STATUS")
-@NamedQueries({
-    @NamedQuery(
-        name = "Status.findLowestRankStatusByProject",
-        query = "SELECT s FROM TaskStatus s WHERE"
-            + " s.project.id = :projectId"
-            + " AND s.rank = (SELECT MIN(s2.rank) FROM TaskStatus s2 WHERE s2.project.id = :projectId)"
-    ),
-    @NamedQuery(
-        name = "Status.findHighestRankStatusByProject",
-        query = "SELECT s FROM TaskStatus s WHERE"
-            + " s.project.id = :projectId"
-            + " AND s.rank = (SELECT MAX(s2.rank) FROM TaskStatus s2 WHERE s2.project.id = :projectId)"
-    ),
-    @NamedQuery(name = "Status.findByName",
-                query = "SELECT s FROM TaskStatus s WHERE s.name = :name AND s.project.id = :projectID"),
-    @NamedQuery(name = "Status.findStatusByProject",
-                query = "SELECT s FROM TaskStatus s WHERE s.project.id = :projectId ORDER BY s.rank ASC"),
+@NamedQuery(
+    name = "Status.findLowestRankStatusByProject",
+    query = "SELECT s FROM TaskStatus s WHERE"
+        + " s.project.id = :projectId"
+        + " AND s.rank = (SELECT MIN(s2.rank) FROM TaskStatus s2 WHERE s2.project.id = :projectId)"
+)
+@NamedQuery(
+    name = "Status.findHighestRankStatusByProject",
+    query = "SELECT s FROM TaskStatus s WHERE"
+        + " s.project.id = :projectId"
+        + " AND s.rank = (SELECT MAX(s2.rank) FROM TaskStatus s2 WHERE s2.project.id = :projectId)"
+)
+@NamedQuery(name = "Status.findByName",
+            query = "SELECT s FROM TaskStatus s WHERE s.name = :name AND s.project.id = :projectID")
+@NamedQuery(name = "Status.findStatusByProject",
+            query = "SELECT s FROM TaskStatus s WHERE s.project.id = :projectId ORDER BY s.rank ASC")
+@EqualsAndHashCode
+public class Status implements Comparable<Status>, Serializable {
 
-        })
-public class Status implements Comparable<Status>{
+  private static final long serialVersionUID = -3079376553215147896L;
+
   @Id
-  @SequenceGenerator(name="SEQ_TASK_STATUS_STATUS_ID", sequenceName="SEQ_TASK_STATUS_STATUS_ID", allocationSize = 1)
-  @GeneratedValue(strategy=GenerationType.AUTO, generator="SEQ_TASK_STATUS_STATUS_ID")
+  @SequenceGenerator(name = "SEQ_TASK_STATUS_STATUS_ID", sequenceName = "SEQ_TASK_STATUS_STATUS_ID", allocationSize = 1)
+  @GeneratedValue(strategy = GenerationType.AUTO, generator = "SEQ_TASK_STATUS_STATUS_ID")
   @Column(name = "STATUS_ID")
-  private long id;
+  private long              id;
 
-  private String name;
+  private String            name;
 
   @Column(name = "STATUS_RANK")
-  private Integer rank;
+  private Integer           rank;
 
-  //This field only used for cascade remove
+  // This field only used for cascade remove
+  @EqualsAndHashCode.Exclude
   @OneToMany(mappedBy = "status", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true)
-  private List<Task> tasks = new ArrayList<Task>();
+  private List<Task>        tasks;
 
   @ManyToOne
+  @EqualsAndHashCode.Exclude
   @JoinColumn(name = "PROJECT_ID")
-  private Project project;
+  private Project           project;
 
   public Status() {
   }
@@ -132,30 +134,9 @@ public class Status implements Comparable<Status>{
     this.project = project;
   }
 
-  public Status clone() {
-    Status status = new Status(getId(), getName(), getRank(), getProject().clone(false));
-
-    return status;
-  }
-
   @Override
-  public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-
-    Status status = (Status) o;
-
-    if (id != status.id) return false;
-    if (name != null ? !name.equals(status.name) : status.name != null) return false;
-    if (project != null ? !project.equals(status.project) : status.project != null) return false;
-    if (rank != null ? !rank.equals(status.rank) : status.rank != null) return false;
-
-    return true;
-  }
-
-  @Override
-  public int hashCode() {
-      return Objects.hash(id, name, rank, project);
+  public Status clone() { // NOSONAR
+    return new Status(getId(), getName(), getRank(), getProject().clone(false));
   }
 
   @Override

--- a/services/src/main/java/org/exoplatform/task/domain/Status.java
+++ b/services/src/main/java/org/exoplatform/task/domain/Status.java
@@ -32,6 +32,7 @@ import jakarta.persistence.NamedQuery;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
+import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 /**
@@ -55,7 +56,7 @@ import lombok.EqualsAndHashCode;
             query = "SELECT s FROM TaskStatus s WHERE s.name = :name AND s.project.id = :projectID")
 @NamedQuery(name = "Status.findStatusByProject",
             query = "SELECT s FROM TaskStatus s WHERE s.project.id = :projectId ORDER BY s.rank ASC")
-@EqualsAndHashCode
+@Data
 public class Status implements Comparable<Status>, Serializable {
 
   private static final long serialVersionUID = -3079376553215147896L;
@@ -73,7 +74,7 @@ public class Status implements Comparable<Status>, Serializable {
 
   // This field only used for cascade remove
   @EqualsAndHashCode.Exclude
-  @OneToMany(mappedBy = "status", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true)
+  @OneToMany(mappedBy = "status", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
   private List<Task>        tasks;
 
   @ManyToOne
@@ -84,11 +85,11 @@ public class Status implements Comparable<Status>, Serializable {
   public Status() {
   }
 
-  //TO REMOVE after removing the TaskServiceMemImpl
   public Status(long id, String name) {
     this.id = id;
     this.name = name;
   }
+
   public Status(long id, String name, Integer rank, Project project) {
     this.id = id;
     this.name = name;
@@ -102,41 +103,9 @@ public class Status implements Comparable<Status>, Serializable {
     this.project = project;
   }
 
-  public long getId() {
-    return id;
-  }
-
-  public void setId(long id) {
-    this.id = id;
-  }
-
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  public Integer getRank() {
-    return rank;
-  }
-
-  public void setRank(Integer rank) {
-    this.rank = rank;
-  }
-
-  public Project getProject() {
-    return project;
-  }
-
-  public void setProject(Project project) {
-    this.project = project;
-  }
-
   @Override
   public Status clone() { // NOSONAR
-    return new Status(getId(), getName(), getRank(), getProject().clone(false));
+    return new Status(getId(), getName(), getRank(), getProject().clone());
   }
 
   @Override

--- a/services/src/main/java/org/exoplatform/task/domain/Task.java
+++ b/services/src/main/java/org/exoplatform/task/domain/Task.java
@@ -16,7 +16,11 @@
  */
 package org.exoplatform.task.domain;
 
-import java.util.*;
+import java.io.Serializable;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.CollectionTable;
@@ -31,23 +35,18 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.NamedQueries;
 import jakarta.persistence.NamedQuery;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import jakarta.persistence.Temporal;
 import jakarta.persistence.TemporalType;
-
-import org.exoplatform.commons.api.persistence.ExoEntity;
-import org.exoplatform.task.dto.StatusDto;
-import org.exoplatform.task.service.TaskBuilder;
+import lombok.EqualsAndHashCode;
 
 /**
  * @author <a href="mailto:tuyennt@exoplatform.com">Tuyen Nguyen The</a>
  */
 @Entity(name = "TaskTask")
-@ExoEntity
 @Table(name = "TASK_TASKS")
 @NamedQuery(
     name = "Task.findByMemberships",
@@ -158,46 +157,49 @@ import org.exoplatform.task.service.TaskBuilder;
 
 @NamedQuery(name = "Task.getAllIds",
         query = "SELECT t.id FROM TaskTask t ORDER BY id ASC LIMIT :limit OFFSET :offset")
+@EqualsAndHashCode
+public class Task implements Serializable {
 
-public class Task {
+  private static final long     serialVersionUID = 1945617316471028822L;
 
-  public static final String PREFIX_CLONE = "Copy of ";
+  public static final String    PREFIX_CLONE     = "Copy of ";
 
   @Id
-  @SequenceGenerator(name="SEQ_TASK_TASKS_TASK_ID", sequenceName="SEQ_TASK_TASKS_TASK_ID", allocationSize = 1)
-  @GeneratedValue(strategy=GenerationType.AUTO, generator="SEQ_TASK_TASKS_TASK_ID")
+  @SequenceGenerator(name = "SEQ_TASK_TASKS_TASK_ID", sequenceName = "SEQ_TASK_TASKS_TASK_ID", allocationSize = 1)
+  @GeneratedValue(strategy = GenerationType.AUTO, generator = "SEQ_TASK_TASKS_TASK_ID")
   @Column(name = "TASK_ID")
-  private long        id;
+  private Long                  id;
 
-  private String      title;
+  private String                title;
 
-  private String      description;
+  private String                description;
 
   @Enumerated(EnumType.ORDINAL)
-  private Priority    priority;
+  private Priority              priority;
 
-  private String      context;
+  private String                context;
 
-  private String      assignee;
+  private String                assignee;
 
-  @ManyToOne(fetch=FetchType.LAZY)
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "STATUS_ID")
-  private Status      status;
+  @EqualsAndHashCode.Exclude
+  private Status                status;
 
   @Column(name = "TASK_RANK")
-  private int         rank;
+  private int                   rank;
 
-  private boolean completed = false;
-
-  @ElementCollection(fetch = FetchType.LAZY)
-  @CollectionTable(name = "TASK_TASK_COWORKERS",
-      joinColumns = @JoinColumn(name = "TASK_ID"))
-  private Set<String> coworker = new HashSet<String>();
+  private boolean               completed        = false;
 
   @ElementCollection(fetch = FetchType.LAZY)
-  @CollectionTable(name = "TASK_TASK_WATCHERS",
-      joinColumns = @JoinColumn(name = "TASK_ID"))
-  private Set<String> watcher =  new HashSet<String>();
+  @CollectionTable(name = "TASK_TASK_COWORKERS", joinColumns = @JoinColumn(name = "TASK_ID"))
+  @EqualsAndHashCode.Exclude
+  private Set<String> coworker;
+
+  @ElementCollection(fetch = FetchType.LAZY)
+  @CollectionTable(name = "TASK_TASK_WATCHERS", joinColumns = @JoinColumn(name = "TASK_ID"))
+  @EqualsAndHashCode.Exclude
+  private Set<String> watcher;
 
   @Column(name = "CREATED_BY")
   private String      createdBy;
@@ -220,14 +222,17 @@ public class Task {
 
   //This field is only used for remove cascade
   @OneToMany(mappedBy = "task", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true)
-  private List<Comment> comments = new ArrayList<Comment>();
+  @EqualsAndHashCode.Exclude
+  private List<Comment> comments; // NOSONAR
 
   //This field is only used for remove cascade
   @OneToMany(mappedBy = "task", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true)
-  private List<ChangeLog> logs = new ArrayList<ChangeLog>();
+  @EqualsAndHashCode.Exclude
+  private List<ChangeLog> logs; // NOSONAR
 
   @OneToMany(mappedBy = "task", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true)
-  private Set<LabelTaskMapping> lblMapping = new HashSet<LabelTaskMapping>();
+  @EqualsAndHashCode.Exclude
+  private Set<LabelTaskMapping> lblMapping;
 
   @Column(name = "ACTIVITY_ID")
   private String activityId;
@@ -236,9 +241,18 @@ public class Task {
     this.priority = Priority.NORMAL;
   }
 
-
-
-  public Task(String title, String description, Priority priority, String context, String assignee, Set<String> coworker, Set<String> watcher, Status status, String createdBy , Date endDate, Date startDate, Date dueDate) {
+  public Task(String title, // NOSONAR
+              String description,
+              Priority priority,
+              String context,
+              String assignee,
+              Set<String> coworker,
+              Set<String> watcher,
+              Status status,
+              String createdBy,
+              Date endDate,
+              Date startDate,
+              Date dueDate) {
     this.title = title;
     this.assignee = assignee;
     this.coworker = coworker;
@@ -253,11 +267,11 @@ public class Task {
     this.status = status;
   }
 
-  public long getId() {
+  public Long getId() {
     return id;
   }
 
-  public void setId(long id) {
+  public void setId(Long id) {
     this.id = id;
   }
 
@@ -389,14 +403,15 @@ public class Task {
     this.activityId = activityId;
   }
 
-  public Task clone() {
-    Set<String> coworkerClone = new HashSet<String>();
-    Set<String> watcherClone = new HashSet<String>();
+  @Override
+  public Task clone() { //NOSONAR
+    Set<String> coworkerClone = new HashSet<>();
+    Set<String> watcherClone = new HashSet<>();
     if (getCoworker() != null) {
-      coworkerClone = new HashSet<String>(getCoworker());
+      coworkerClone = new HashSet<>(getCoworker());
     }
     if (getWatcher() != null) {
-      watcherClone = new HashSet<String>(getWatcher());
+      watcherClone = new HashSet<>(getWatcher());
     }
     Task newTask = new Task(this.getTitle(), this.getDescription(), this.getPriority(), this.getContext(), this.getAssignee(), coworkerClone, watcherClone, this.getStatus() != null ? this.getStatus().clone() : null, this.getCreatedBy() , this.getEndDate(), this.getStartDate(), this.getDueDate());
 
@@ -407,37 +422,5 @@ public class Task {
     newTask.setId(getId());
 
     return newTask;
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
-
-    Task task = (Task) o;
-
-    if (completed != task.completed) return false;
-    if (id != task.id) return false;
-    if (assignee != null ? !assignee.equals(task.assignee) : task.assignee != null) return false;
-    if (context != null ? !context.equals(task.context) : task.context != null) return false;
-    if (coworker != null ? !coworker.equals(task.coworker) : task.coworker != null) return false;
-    if (watcher != null ? !watcher.equals(task.watcher) : task.watcher != null) return false;
-    if (createdBy != null ? !createdBy.equals(task.createdBy) : task.createdBy != null) return false;
-    if (createdTime != null ? !createdTime.equals(task.createdTime) : task.createdTime != null) return false;
-    if (description != null ? !description.equals(task.description) : task.description != null) return false;
-    if (dueDate != null ? !dueDate.equals(task.dueDate) : task.dueDate != null) return false;
-    if (priority != task.priority) return false;
-    if (startDate != null ? !startDate.equals(task.startDate) : task.startDate != null) return false;
-    if (endDate != null ? !endDate.equals(task.endDate) : task.endDate != null) return false;
-    if (status != null ? !status.equals(task.status) : task.status != null) return false;
-    if (title != null ? !title.equals(task.title) : task.title != null) return false;
-
-    return true;
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(id, title, description, priority, context, assignee, status, completed, coworker,watcher,
-            createdBy, createdTime, startDate, endDate, dueDate);
   }
 }

--- a/services/src/main/java/org/exoplatform/task/domain/Task.java
+++ b/services/src/main/java/org/exoplatform/task/domain/Task.java
@@ -41,6 +41,7 @@ import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import jakarta.persistence.Temporal;
 import jakarta.persistence.TemporalType;
+import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 /**
@@ -157,7 +158,7 @@ import lombok.EqualsAndHashCode;
 
 @NamedQuery(name = "Task.getAllIds",
         query = "SELECT t.id FROM TaskTask t ORDER BY id ASC LIMIT :limit OFFSET :offset")
-@EqualsAndHashCode
+@Data
 public class Task implements Serializable {
 
   private static final long     serialVersionUID = 1945617316471028822L;
@@ -221,18 +222,18 @@ public class Task implements Serializable {
   private Date        dueDate;
 
   //This field is only used for remove cascade
-  @OneToMany(mappedBy = "task", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true)
+  @OneToMany(mappedBy = "task", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
   @EqualsAndHashCode.Exclude
   private List<Comment> comments; // NOSONAR
 
   //This field is only used for remove cascade
-  @OneToMany(mappedBy = "task", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true)
+  @OneToMany(mappedBy = "task", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
   @EqualsAndHashCode.Exclude
   private List<ChangeLog> logs; // NOSONAR
 
-  @OneToMany(mappedBy = "task", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true)
+  @OneToMany(mappedBy = "task", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
   @EqualsAndHashCode.Exclude
-  private Set<LabelTaskMapping> lblMapping;
+  private List<LabelTaskMapping> labels;
 
   @Column(name = "ACTIVITY_ID")
   private String activityId;
@@ -265,142 +266,6 @@ public class Task implements Serializable {
     this.endDate = endDate;
     this.dueDate = dueDate;
     this.status = status;
-  }
-
-  public Long getId() {
-    return id;
-  }
-
-  public void setId(Long id) {
-    this.id = id;
-  }
-
-  public String getTitle() {
-    return title;
-  }
-
-  public void setTitle(String title) {
-    this.title = title;
-  }
-
-  public String getDescription() {
-    return description;
-  }
-
-  public void setDescription(String description) {
-    this.description = description;
-  }
-
-  public Priority getPriority() {
-    return priority;
-  }
-
-  public void setPriority(Priority priority) {
-    this.priority = priority;
-  }
-
-  public String getContext() {
-    return context;
-  }
-
-  public void setContext(String context) {
-    this.context = context;
-  }
-
-  public String getAssignee() {
-    return assignee;
-  }
-
-  public void setAssignee(String assignee) {
-    this.assignee = assignee;
-  }
-
-  public Status getStatus() {
-    return status;
-  }
-
-  public void setStatus(Status status) {
-    this.status = status;
-  }
-
-  public int getRank() {
-    return rank;
-  }
-
-  public void setRank(int rank) {
-    this.rank = rank;
-  }
-
-  public boolean isCompleted() {
-    return completed;
-  }
-
-  public void setCompleted(boolean completed) {
-    this.completed = completed;
-  }
-
-  public String getCreatedBy() {
-    return createdBy;
-  }
-
-  public void setCreatedBy(String createdBy) {
-    this.createdBy = createdBy;
-  }
-
-  public Date getCreatedTime() {
-    return createdTime;
-  }
-
-  public void setCreatedTime(Date createdTime) {
-    this.createdTime = createdTime;
-  }
-
-  public Date getEndDate() {
-    return endDate;
-  }
-
-  public void setEndDate(Date endDate) {
-    this.endDate = endDate;
-  }
-
-  public Date getStartDate() {
-    return startDate;
-  }
-
-  public void setStartDate(Date startDate) {
-    this.startDate = startDate;
-  }
-
-  public Date getDueDate() {
-    return dueDate;
-  }
-
-  public void setDueDate(Date dueDate) {
-    this.dueDate = dueDate;
-  }
-
-  public Set<String> getCoworker() {
-    return coworker;
-  }
-
-  public void setCoworker(Set<String> coworker) {
-    this.coworker = coworker;
-  }
-
-  public Set<String> getWatcher() {
-    return watcher;
-  }
-
-  public void setWatcher(Set<String> watcher) {
-    this.watcher = watcher;
-  }
-
-  public String getActivityId() {
-    return activityId;
-  }
-
-  public void setActivityId(String activityId) {
-    this.activityId = activityId;
   }
 
   @Override

--- a/services/src/main/java/org/exoplatform/task/domain/UserSetting.java
+++ b/services/src/main/java/org/exoplatform/task/domain/UserSetting.java
@@ -18,6 +18,7 @@ package org.exoplatform.task.domain;
 
 import java.io.Serializable;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import jakarta.persistence.Column;
@@ -27,6 +28,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.JoinTable;
 import jakarta.persistence.ManyToMany;
 import jakarta.persistence.Table;
+import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 /**
@@ -34,7 +36,7 @@ import lombok.EqualsAndHashCode;
  */
 @Entity(name = "TaskUserSetting")
 @Table(name = "TASK_USER_SETTINGS")
-@EqualsAndHashCode
+@Data
 public class UserSetting implements Serializable {
 
   private static final long serialVersionUID  = 731610709234552969L;
@@ -68,38 +70,11 @@ public class UserSetting implements Serializable {
     this.username = username;
   }
 
-  public String getUsername() {
-    return username;
-  }
-
-  public boolean isShowHiddenProject() {
-    return showHiddenProject;
-  }
-
-  public void setShowHiddenProject(boolean showHiddenProject) {
-    this.showHiddenProject = showHiddenProject;
-  }
-
-  public boolean isShowHiddenLabel() {
-    return showHiddenLabel;
-  }
-
-  public void setShowHiddenLabel(boolean showHiddenLabel) {
-    this.showHiddenLabel = showHiddenLabel;
-  }
-
-  public Set<Project> getHiddenProjects() {
-    return hiddenProjects;
-  }
-
-  public void setHiddenProjects(Set<Project> hiddenProjects) {
-    this.hiddenProjects = hiddenProjects;
-  }
-
   @Override
   public UserSetting clone() { // NOSONAR
     UserSetting setting = new UserSetting(getUsername());
     setting.setShowHiddenProject(isShowHiddenProject());
     return setting;
   }
+
 }

--- a/services/src/main/java/org/exoplatform/task/domain/UserSetting.java
+++ b/services/src/main/java/org/exoplatform/task/domain/UserSetting.java
@@ -16,19 +16,29 @@
  */
 package org.exoplatform.task.domain;
 
-import org.exoplatform.commons.api.persistence.ExoEntity;
-
-import jakarta.persistence.*;
+import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Set;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.Table;
+import lombok.EqualsAndHashCode;
 
 /**
  * @author <a href="mailto:tuyennt@exoplatform.com">Tuyen Nguyen The</a>.
  */
 @Entity(name = "TaskUserSetting")
-@ExoEntity
 @Table(name = "TASK_USER_SETTINGS")
-public class UserSetting {
+@EqualsAndHashCode
+public class UserSetting implements Serializable {
+
+  private static final long serialVersionUID  = 731610709234552969L;
+
   @Id
   @Column(name = "USERNAME")
   private String username;
@@ -41,14 +51,17 @@ public class UserSetting {
 
   @ManyToMany
   @JoinTable(
-          name = "TASK_HIDDEN_PROJECTS",
-          joinColumns = {@JoinColumn(name = "USERNAME", referencedColumnName = "USERNAME")},
-          inverseJoinColumns = {@JoinColumn(name = "PROJECT_ID", referencedColumnName = "PROJECT_ID")}
+    name = "TASK_HIDDEN_PROJECTS",
+    joinColumns = {
+      @JoinColumn(name = "USERNAME", referencedColumnName = "USERNAME")
+    },
+    inverseJoinColumns = {
+      @JoinColumn(name = "PROJECT_ID", referencedColumnName = "PROJECT_ID")
+    }
   )
-  private Set<Project> hiddenProjects = new HashSet<Project>();
+  private Set<Project> hiddenProjects = new HashSet<>();
 
   public UserSetting() {
-
   }
 
   public UserSetting(String username) {
@@ -83,31 +96,10 @@ public class UserSetting {
     this.hiddenProjects = hiddenProjects;
   }
 
-  //TODO: This method does not work any more, re-implement it in ProjectService
-  public boolean isHiddenProject(Project project) {
-    if (project == null) return false;
-
-    for (Project p : hiddenProjects) {
-      if (p.getId() == project.getId()) {
-        return true;
-      }
-    }
-    return false;
-  }
-
   @Override
-  public UserSetting clone() {
+  public UserSetting clone() { // NOSONAR
     UserSetting setting = new UserSetting(getUsername());
     setting.setShowHiddenProject(isShowHiddenProject());
-
-    //TODO: clone hiddenProjects here is not good for performance
-    Set<Project> hiddenProjects = new HashSet<Project>();
-    if (getHiddenProjects() != null) {
-      for (Project p : getHiddenProjects()) {
-        hiddenProjects.add(p.clone(false));
-      }
-    }
-    setting.setHiddenProjects(hiddenProjects);
     return setting;
   }
 }

--- a/services/src/main/java/org/exoplatform/task/dto/UserSettingDto.java
+++ b/services/src/main/java/org/exoplatform/task/dto/UserSettingDto.java
@@ -22,7 +22,6 @@ import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Set;
 
-
 @Data
 public class UserSettingDto implements Serializable {
     private String username;
@@ -36,10 +35,10 @@ public class UserSettingDto implements Serializable {
     public UserSettingDto clone() {
         UserSettingDto setting = new UserSettingDto();
         setting.setShowHiddenProject(isShowHiddenProject());
-        Set<Project> hiddenProjects = new HashSet<Project>();
+        Set<Project> hiddenProjects = new HashSet<>();
         if (getHiddenProjects() != null) {
             for (Project p : getHiddenProjects()) {
-                hiddenProjects.add(p.clone(false));
+                hiddenProjects.add(p.clone());
             }
         }
         setting.setHiddenProjects(hiddenProjects);

--- a/services/src/main/java/org/exoplatform/task/rest/ProjectRestService.java
+++ b/services/src/main/java/org/exoplatform/task/rest/ProjectRestService.java
@@ -644,7 +644,7 @@ public class ProjectRestService implements ResourceContainer {
   @Consumes(MediaType.APPLICATION_JSON)
   @RolesAllowed("users")
   @Operation(summary = "Delete Project", method = "DELETE", description = "This deletes the Project")
-  @ApiResponses(value = { @ApiResponse(responseCode = "200", description = "Project deleted"),
+  @ApiResponses(value = { @ApiResponse(responseCode = "204", description = "Project deleted"),
       @ApiResponse(responseCode = "400", description = "Invalid query input"),
       @ApiResponse(responseCode = "401", description = "User not authorized to delete the Project"),
       @ApiResponse(responseCode = "500", description = "Internal server error") })
@@ -667,7 +667,7 @@ public class ProjectRestService implements ResourceContainer {
       }
 
       projectService.removeProject(projectId, deleteChild);
-      return Response.ok(Response.Status.OK).build();
+      return Response.noContent().build();
     } catch (Exception e) {
       LOG.error("Can't deleteProject {}", projectId, e);
       return Response.serverError().entity(e.getMessage()).build();

--- a/services/src/main/java/org/exoplatform/task/service/LabelService.java
+++ b/services/src/main/java/org/exoplatform/task/service/LabelService.java
@@ -20,10 +20,11 @@ import java.util.List;
 
 import org.exoplatform.commons.api.persistence.ExoTransactional;
 import org.exoplatform.services.security.Identity;
-import org.exoplatform.task.domain.Label;
 import org.exoplatform.task.dto.LabelDto;
 import org.exoplatform.task.dto.TaskDto;
 import org.exoplatform.task.exception.EntityNotFoundException;
+
+import io.meeds.task.domain.LabelField;
 
 public interface LabelService {
   List<LabelDto> findLabelsByUser(String username, int offset, int limit);
@@ -37,7 +38,7 @@ public interface LabelService {
   LabelDto createLabel(LabelDto label);
 
   @ExoTransactional
-  LabelDto updateLabel(LabelDto label, List<Label.FIELDS> fields) throws EntityNotFoundException;
+  LabelDto updateLabel(LabelDto label, List<LabelField> fields) throws EntityNotFoundException;
 
   LabelDto updateLabel(LabelDto label) throws EntityNotFoundException;
 

--- a/services/src/main/java/org/exoplatform/task/service/impl/CommentServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/task/service/impl/CommentServiceImpl.java
@@ -22,7 +22,6 @@ import static org.exoplatform.task.util.TaskUtil.broadcastEvent;
 
 import java.util.List;
 
-import org.exoplatform.commons.api.persistence.ExoTransactional;
 import org.exoplatform.services.listener.ListenerService;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
@@ -82,7 +81,6 @@ public class CommentServiceImpl implements CommentService {
     }
 
     @Override
-    @ExoTransactional
     public CommentDto addComment(TaskDto task,
                                  long parentCommentId,
                                  String username,
@@ -90,7 +88,7 @@ public class CommentServiceImpl implements CommentService {
       CommentDto commentDto = commentStorage.addComment(task, parentCommentId, username, comment);
       if (commentDto != null) {
         broadcastEvent(listenerService, TASK_COMMENT_CREATED, commentDto.getTask(), commentDto);
-        if (commentDto.getTask().getStatus() != null && commentDto.getTask().getStatus().getProject() != null) {
+        if (commentDto.getTask() != null && commentDto.getTask().getStatus() != null && commentDto.getTask().getStatus().getProject() != null) {
           broadcastEvent(listenerService, "exo.project.projectModified", null, commentDto.getTask().getStatus().getProject());
         }
       }
@@ -98,13 +96,11 @@ public class CommentServiceImpl implements CommentService {
     }
 
     @Override
-    @ExoTransactional
     public CommentDto addComment(TaskDto task, String username, String comment) throws EntityNotFoundException {
         return addComment(task, 0, username, comment);
     }
 
     @Override
-    @ExoTransactional
     public void removeComment(long commentId) throws EntityNotFoundException {
 
       CommentDto comment = commentStorage.getComment(commentId);

--- a/services/src/main/java/org/exoplatform/task/service/impl/LabelServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/task/service/impl/LabelServiceImpl.java
@@ -16,6 +16,10 @@
  */
 package org.exoplatform.task.service.impl;
 
+import java.util.List;
+
+import javax.inject.Inject;
+
 import org.exoplatform.commons.api.persistence.ExoTransactional;
 import org.exoplatform.services.listener.ListenerService;
 import org.exoplatform.services.log.ExoLogger;
@@ -23,7 +27,6 @@ import org.exoplatform.services.log.Log;
 import org.exoplatform.services.security.ConversationState;
 import org.exoplatform.services.security.Identity;
 import org.exoplatform.task.dao.DAOHandler;
-import org.exoplatform.task.domain.Label;
 import org.exoplatform.task.domain.LabelTaskMapping;
 import org.exoplatform.task.dto.LabelDto;
 import org.exoplatform.task.dto.TaskDto;
@@ -33,8 +36,7 @@ import org.exoplatform.task.storage.LabelStorage;
 import org.exoplatform.task.storage.ProjectStorage;
 import org.exoplatform.task.util.StorageUtil;
 
-import javax.inject.Inject;
-import java.util.List;
+import io.meeds.task.domain.LabelField;
 
 public class LabelServiceImpl implements LabelService {
 
@@ -91,14 +93,14 @@ public class LabelServiceImpl implements LabelService {
 
     @Override
     @ExoTransactional
-    public LabelDto updateLabel(LabelDto label, List<Label.FIELDS> fields) throws EntityNotFoundException {
+    public LabelDto updateLabel(LabelDto label, List<LabelField> fields) throws EntityNotFoundException {
         LabelDto lb = getLabel(label.getId());
         if (lb == null) {
             throw new EntityNotFoundException(label.getId(), LabelDto.class);
         }
 
         //Todo: validate input and throw exception if need
-        for (Label.FIELDS field : fields) {
+        for (LabelField field : fields) {
             switch (field) {
                 case NAME:
                     lb.setName(label.getName());

--- a/services/src/main/java/org/exoplatform/task/service/impl/ProjectServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/task/service/impl/ProjectServiceImpl.java
@@ -21,7 +21,6 @@ import java.util.*;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
-import org.exoplatform.commons.api.persistence.ExoTransactional;
 import org.exoplatform.commons.utils.ListAccess;
 import org.exoplatform.services.listener.ListenerService;
 import org.exoplatform.services.log.ExoLogger;
@@ -38,7 +37,6 @@ import org.exoplatform.task.service.ProjectService;
 import org.exoplatform.task.service.StatusService;
 import org.exoplatform.task.service.TaskService;
 import org.exoplatform.task.storage.ProjectStorage;
-import org.exoplatform.task.storage.StatusStorage;
 import org.exoplatform.task.util.StorageUtil;
 
 @Singleton
@@ -80,14 +78,12 @@ public class ProjectServiceImpl implements ProjectService {
   }
 
   @Override
-  @ExoTransactional
   public ProjectDto createProject(ProjectDto project) {
     ProjectDto proj = projectStorage.createProject(project);
     return proj;
   }
 
   @Override
-  @ExoTransactional
   public ProjectDto createProject(ProjectDto project, long parentId) throws EntityNotFoundException {
     ProjectDto parentProject = projectStorage.getProject(parentId);
     if (parentProject != null) {
@@ -115,21 +111,18 @@ public class ProjectServiceImpl implements ProjectService {
   }
 
   @Override
-  @ExoTransactional
   public ProjectDto updateProject(ProjectDto proj) {
     proj.setLastModifiedDate(System.currentTimeMillis());
     return projectStorage.updateProject(proj);
   }
 
   @Override
-  @ExoTransactional
   public void updateProjectNoReturn(ProjectDto proj) {
     proj.setLastModifiedDate(System.currentTimeMillis());
     projectStorage.updateProjectNoReturn(proj);
   }
 
   @Override
-  @ExoTransactional
   public void removeProject(long id, boolean deleteChild) throws EntityNotFoundException {
     ProjectDto project = getProject(id);
     if (project == null)
@@ -138,7 +131,6 @@ public class ProjectServiceImpl implements ProjectService {
   }
 
   @Override
-  @ExoTransactional
   public ProjectDto cloneProject(long id, boolean cloneTask) throws Exception {
 
     ProjectDto project = getProject(id); // Can throw ProjectNotFoundException
@@ -164,7 +156,7 @@ public class ProjectServiceImpl implements ProjectService {
         StatusDto s = statusService.createStatus(newProject, st.getName());
         if (cloneTask) {
           taskQuery = new TaskQuery();
-          taskQuery.setStatus(StorageUtil.statusToEntity(st));
+          taskQuery.setStatus(StorageUtil.getStatusEntityById(st.getId()));
           for (TaskDto t : taskService.findTasks(taskQuery, 0, -1)) {
             TaskDto newTask = t.clone();
             newTask.setId(0);

--- a/services/src/main/java/org/exoplatform/task/service/impl/StatusServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/task/service/impl/StatusServiceImpl.java
@@ -139,7 +139,7 @@ public class StatusServiceImpl implements StatusService {
     @Override
     @ExoTransactional
     public void removeStatus(long statusID) throws Exception {
-        statusStorage.removeStatus(statusID);
+        statusStorage.removeStatus(statusID, false);
     }
 
     @Override

--- a/services/src/main/java/org/exoplatform/task/service/impl/TaskServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/task/service/impl/TaskServiceImpl.java
@@ -17,8 +17,8 @@
 package org.exoplatform.task.service.impl;
 
 import org.apache.commons.lang3.StringUtils;
-import org.exoplatform.commons.api.persistence.ExoTransactional;
 import org.exoplatform.commons.utils.CommonsUtils;
+import org.exoplatform.container.component.RequestLifeCycle;
 import org.exoplatform.services.listener.ListenerService;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
@@ -73,9 +73,9 @@ public class TaskServiceImpl implements TaskService {
     }
 
     @Override
-    @ExoTransactional
     public TaskDto createTask(TaskDto task) {
       TaskDto result = taskStorage.createTask(task);
+      RequestLifeCycle.restartTransaction();
       TaskPayload event = new TaskPayload(null, result);
       broadcastEvent(listenerService, TASK_CREATED, null, event);
       if (result.getStatus() != null && result.getStatus().getProject() != null) {
@@ -85,7 +85,6 @@ public class TaskServiceImpl implements TaskService {
     }
 
     @Override
-    @ExoTransactional
     public TaskDto updateTask(TaskDto task) {
       if (task == null) {
         throw new IllegalArgumentException("TaskDto must not be NULL");
@@ -101,13 +100,11 @@ public class TaskServiceImpl implements TaskService {
     }
 
     @Override
-    @ExoTransactional
     public void updateTaskOrder(long currentTaskId, Status newStatus, long[] orders) {
         taskStorage.updateTaskOrder(currentTaskId, newStatus, orders);
     }
 
     @Override
-    @ExoTransactional
     public void removeTask(long id) throws EntityNotFoundException {
         TaskDto task = getTask(id);// Can throw TaskNotFoundException
         taskStorage.delete(task);
@@ -115,7 +112,6 @@ public class TaskServiceImpl implements TaskService {
     }
 
     @Override
-    @ExoTransactional
     public TaskDto cloneTask(long id) throws EntityNotFoundException {
         TaskDto task = getTask(id);// Can throw TaskNotFoundException
         TaskDto newTask = task.clone();
@@ -142,7 +138,6 @@ public class TaskServiceImpl implements TaskService {
 
 
     @Override
-    @ExoTransactional
     public ChangeLogEntry addTaskLog(long id, String username, String actionName, String target) throws EntityNotFoundException {
         ChangeLogEntry log = new ChangeLogEntry();
         log.setTask(StorageUtil.taskToEntity(getTask(id)));

--- a/services/src/main/java/org/exoplatform/task/storage/LabelStorage.java
+++ b/services/src/main/java/org/exoplatform/task/storage/LabelStorage.java
@@ -19,10 +19,11 @@ package org.exoplatform.task.storage;
 import java.util.List;
 
 import org.exoplatform.services.security.Identity;
-import org.exoplatform.task.domain.Label;
 import org.exoplatform.task.dto.LabelDto;
 import org.exoplatform.task.dto.TaskDto;
 import org.exoplatform.task.exception.EntityNotFoundException;
+
+import io.meeds.task.domain.LabelField;
 
 public interface LabelStorage {
 
@@ -36,7 +37,7 @@ public interface LabelStorage {
 
   LabelDto createLabel(LabelDto label);
 
-  LabelDto updateLabel(LabelDto label, List<Label.FIELDS> fields) throws EntityNotFoundException;
+  LabelDto updateLabel(LabelDto label, List<LabelField> fields) throws EntityNotFoundException;
 
   void removeLabel(long labelId);
 

--- a/services/src/main/java/org/exoplatform/task/storage/ProjectStorage.java
+++ b/services/src/main/java/org/exoplatform/task/storage/ProjectStorage.java
@@ -75,18 +75,6 @@ public interface ProjectStorage {
     void removeProject(long projectId, boolean deleteChild) throws EntityNotFoundException;
 
     /**
-     * Clone a project with given <code>projectId</code>. If <code>cloneTask</code> is true,
-     * it will also clone all non-completed tasks from the project.
-     *
-     * @param projectId The id of a project which it copies from.
-     * @param cloneTask If false, it will clone only project metadata.
-     *                  Otherwise, it also clones all non-completed tasks from the project.
-     * @return The cloned project.
-     * @throws EntityNotFoundException when user is not authorized to clone project.
-     */
-    ProjectDto cloneProject(long projectId, boolean cloneTask) throws EntityNotFoundException;
-
-    /**
      * Return a list of children of a parent project with given <code>parentId</code>.
      *
      * @param parentId The parent id of a project.

--- a/services/src/main/java/org/exoplatform/task/storage/StatusStorage.java
+++ b/services/src/main/java/org/exoplatform/task/storage/StatusStorage.java
@@ -55,7 +55,7 @@ public interface StatusStorage {
 
   StatusDto createStatus(ProjectDto project, String status, int rank) throws NotAllowedOperationOnEntityException;
 
-  void removeStatus(long statusId) throws Exception;
+  void removeStatus(long statusId, boolean removeAll) throws Exception;
 
   StatusDto updateStatus(long statusId, String statusName) throws EntityNotFoundException, NotAllowedOperationOnEntityException;
 

--- a/services/src/main/java/org/exoplatform/task/storage/impl/CommentStorageImpl.java
+++ b/services/src/main/java/org/exoplatform/task/storage/impl/CommentStorageImpl.java
@@ -122,7 +122,9 @@ public class CommentStorageImpl implements CommentStorage {
             }
             newComment.setParentComment(parentComment);
         }
-        return  StorageUtil.commentToDto(daoHandler.getCommentHandler().create(StorageUtil.commentToEntity(newComment)),projectStorage);
+        Comment commentEntity = StorageUtil.commentToEntity(newComment);
+        commentEntity.setId(null);
+        return  StorageUtil.commentToDto(daoHandler.getCommentHandler().create(commentEntity),projectStorage);
     }
 
     @Override

--- a/services/src/main/java/org/exoplatform/task/storage/impl/LabelStorageImpl.java
+++ b/services/src/main/java/org/exoplatform/task/storage/impl/LabelStorageImpl.java
@@ -29,13 +29,14 @@ import org.exoplatform.services.log.Log;
 import org.exoplatform.services.security.Identity;
 import org.exoplatform.task.dao.DAOHandler;
 import org.exoplatform.task.domain.Label;
-import org.exoplatform.task.domain.Task;
 import org.exoplatform.task.dto.LabelDto;
 import org.exoplatform.task.dto.TaskDto;
 import org.exoplatform.task.exception.EntityNotFoundException;
 import org.exoplatform.task.storage.LabelStorage;
 import org.exoplatform.task.storage.ProjectStorage;
 import org.exoplatform.task.util.StorageUtil;
+
+import io.meeds.task.domain.LabelField;
 
 public class LabelStorageImpl implements LabelStorage {
 
@@ -96,7 +97,7 @@ public class LabelStorageImpl implements LabelStorage {
   }
 
   @Override
-  public LabelDto updateLabel(LabelDto label, List<Label.FIELDS> fields) throws EntityNotFoundException {
+  public LabelDto updateLabel(LabelDto label, List<LabelField> fields) throws EntityNotFoundException {
     return null;
   }
 

--- a/services/src/main/java/org/exoplatform/task/storage/impl/ProjectStorageImpl.java
+++ b/services/src/main/java/org/exoplatform/task/storage/impl/ProjectStorageImpl.java
@@ -104,8 +104,13 @@ public class ProjectStorageImpl implements ProjectStorage {
     @Override
     public List<ProjectDto> getSubProjects(long parentId, int offset, int limit) throws Exception {
         ProjectDto parent = getProject(parentId);
-        return Arrays.asList(daoHandler.getProjectHandler().findSubProjects(StorageUtil.projectToEntity(parent)).load(offset, limit)).stream().map((Project project) -> StorageUtil.projectToDto(project,this)).collect(Collectors.toList());
-
+        return parent == null ? new ArrayList<>() :
+                              Arrays.asList(daoHandler.getProjectHandler()
+                                                      .findSubProjects(StorageUtil.getProjectEntityById(parent.getId()))
+                                                      .load(offset, limit))
+                                    .stream()
+                                    .map((Project project) -> StorageUtil.projectToDto(project, this))
+                                    .toList();
     }
 
     @Override
@@ -113,7 +118,7 @@ public class ProjectStorageImpl implements ProjectStorage {
         try {
             return Arrays.asList(daoHandler.getProjectHandler().findProjects(query).load(offset, limit)).stream().map((Project project) -> StorageUtil.projectToDto(project,this)).collect(Collectors.toList());
         } catch (Exception e) {
-            return new ArrayList<ProjectDto>();
+            return new ArrayList<>();
         }
 
     }

--- a/services/src/main/java/org/exoplatform/task/storage/impl/ProjectStorageImpl.java
+++ b/services/src/main/java/org/exoplatform/task/storage/impl/ProjectStorageImpl.java
@@ -16,28 +16,32 @@
  */
 package org.exoplatform.task.storage.impl;
 
-import org.exoplatform.services.log.ExoLogger;
-import org.exoplatform.services.log.Log;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.apache.commons.collections4.CollectionUtils;
+
+import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.task.dao.DAOHandler;
 import org.exoplatform.task.dao.OrderBy;
 import org.exoplatform.task.dao.ProjectQuery;
 import org.exoplatform.task.domain.Project;
+import org.exoplatform.task.domain.Status;
 import org.exoplatform.task.dto.ProjectDto;
 import org.exoplatform.task.exception.EntityNotFoundException;
 import org.exoplatform.task.storage.ProjectStorage;
+import org.exoplatform.task.storage.StatusStorage;
 import org.exoplatform.task.util.StorageUtil;
 
-import javax.inject.Inject;
-import java.util.*;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
+import lombok.SneakyThrows;
 
 public class ProjectStorageImpl implements ProjectStorage {
-
-    private static final Log LOG = ExoLogger.getExoLogger(ProjectStorageImpl.class);
-
-    private static final Pattern pattern = Pattern.compile("@([^\\s]+)|@([^\\s]+)$");
-
 
     @Inject
     private final DAOHandler daoHandler;
@@ -58,7 +62,7 @@ public class ProjectStorageImpl implements ProjectStorage {
         ProjectQuery query = new ProjectQuery();
         query.setId(projectId);
         List<String> manager = daoHandler.getProjectHandler().selectProjectField(query, "manager");
-        return new HashSet<String>(manager);
+        return new HashSet<>(manager);
     }
 
     @Override
@@ -66,7 +70,7 @@ public class ProjectStorageImpl implements ProjectStorage {
         ProjectQuery query = new ProjectQuery();
         query.setId(projectId);
         List<String> manager = daoHandler.getProjectHandler().selectProjectField(query, "participator");
-        return new HashSet<String>(manager);
+        return new HashSet<>(manager);
     }
 
     @Override
@@ -93,12 +97,11 @@ public class ProjectStorageImpl implements ProjectStorage {
     public void removeProject(long projectId, boolean deleteChild) throws EntityNotFoundException {
         ProjectDto project = getProject(projectId);
         if (project == null) throw new EntityNotFoundException(projectId, Project.class);
+        List<Status> statuses = daoHandler.getStatusHandler().getStatuses(projectId);
+        if (CollectionUtils.isNotEmpty(statuses)) {
+          statuses.forEach(this::removeStatus);
+        }
         daoHandler.getProjectHandler().removeProject(projectId, deleteChild);
-    }
-
-    @Override
-    public ProjectDto cloneProject(long projectId, boolean cloneTask) throws EntityNotFoundException {
-        return null;
     }
 
     @Override
@@ -138,7 +141,7 @@ public class ProjectStorageImpl implements ProjectStorage {
         try {
             return Arrays.asList(daoHandler.getProjectHandler().findAllByMembershipsAndKeyword(memberships, keyword, order).load(offset, limit)).stream().map((Project project) -> StorageUtil.projectToDto(project,this)).collect(Collectors.toList());
         } catch (Exception e) {
-            return new ArrayList<ProjectDto>();
+            return new ArrayList<>();
         }
     }
 
@@ -147,7 +150,7 @@ public class ProjectStorageImpl implements ProjectStorage {
         try {
             return daoHandler.getProjectHandler().findCollaboratedProjects(userName,keyword,offset, limit).stream().map((Project project) -> StorageUtil.projectToDto(project,this)).collect(Collectors.toList());
         } catch (Exception e) {
-            return new ArrayList<ProjectDto>();
+            return new ArrayList<>();
         }
     }
 
@@ -156,7 +159,7 @@ public class ProjectStorageImpl implements ProjectStorage {
         try {
             return daoHandler.getProjectHandler().findNotEmptyProjects(memberships,keyword,offset, limit).stream().map((Project project) -> StorageUtil.projectToDto(project,this)).collect(Collectors.toList());
         } catch (Exception e) {
-            return new ArrayList<ProjectDto>();
+            return new ArrayList<>();
         }
     }
 
@@ -186,6 +189,12 @@ public class ProjectStorageImpl implements ProjectStorage {
             return 0;
         }
 
+    }
+
+    @SneakyThrows
+    private void removeStatus(Status status) {
+      StatusStorage statusStorage = ExoContainerContext.getService(StatusStorage.class);
+      statusStorage.removeStatus(status.getId(), true);
     }
 
 }

--- a/services/src/main/java/org/exoplatform/task/storage/impl/StatusStorageImpl.java
+++ b/services/src/main/java/org/exoplatform/task/storage/impl/StatusStorageImpl.java
@@ -16,12 +16,15 @@
  */
 package org.exoplatform.task.storage.impl;
 
-import java.util.*;
-import java.util.regex.Pattern;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;
-import jakarta.persistence.NonUniqueResultException;
 
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
@@ -39,11 +42,11 @@ import org.exoplatform.task.storage.StatusStorage;
 import org.exoplatform.task.storage.TaskStorage;
 import org.exoplatform.task.util.StorageUtil;
 
+import jakarta.persistence.NonUniqueResultException;
+
 public class StatusStorageImpl implements StatusStorage {
 
   private static final Log     LOG     = ExoLogger.getExoLogger(StatusStorageImpl.class);
-
-  private static final Pattern pattern = Pattern.compile("@([^\\s]+)|@([^\\s]+)$");
 
   @Inject
   private final DAOHandler     daoHandler;
@@ -51,9 +54,14 @@ public class StatusStorageImpl implements StatusStorage {
   @Inject
   private final ProjectStorage projectStorage;
 
-  public StatusStorageImpl(DAOHandler daoHandler, ProjectStorage projectStorage) {
+  private final TaskStorage    taskStorage;
+
+  public StatusStorageImpl(DAOHandler daoHandler,
+                           TaskStorage taskStorage,
+                           ProjectStorage projectStorage) {
     this.daoHandler = daoHandler;
     this.projectStorage = projectStorage;
+    this.taskStorage = taskStorage;
   }
 
   @Override
@@ -133,26 +141,27 @@ public class StatusStorageImpl implements StatusStorage {
   }
 
   @Override
-  public void removeStatus(long statusId) throws Exception {
-    StatusHandler handler = daoHandler.getStatusHandler();
-    Status st = handler.find(statusId);
+  public void removeStatus(long statusId, boolean removeAll) throws Exception {
+    Status st = daoHandler.getStatusHandler().find(statusId);
     if (st == null) {
       throw new EntityNotFoundException(statusId, Status.class);
     }
 
-    Project project = st.getProject();
-    Status altStatus = findAltStatus(st, project);
-    if (altStatus == null) {
-      throw new NotAllowedOperationOnEntityException(statusId, Status.class, "Delete last status");
-    }
     List<Task> tasks = daoHandler.getTaskHandler().getByStatus(statusId);
-    for(Task task : tasks){
-      task.setStatus(altStatus);
+    if (removeAll) {
+      tasks.forEach(task -> taskStorage.delete(taskStorage.getTaskById(task.getId())));
+    } else {
+      Project project = st.getProject();
+      Status altStatus = findAltStatus(st, project);
+      if (altStatus == null) {
+        throw new NotAllowedOperationOnEntityException(statusId, Status.class, "Delete last status");
+      }
+      for (Task task : tasks) {
+        task.setStatus(altStatus);
+      }
+      daoHandler.getTaskHandler().updateAll(tasks);
     }
-    daoHandler.getTaskHandler().updateAll(tasks);
-    //
-    st.setProject(null);
-    handler.delete(st);
+    daoHandler.getStatusHandler().delete(st);
   }
 
   @Override

--- a/services/src/main/java/org/exoplatform/task/storage/impl/StatusStorageImpl.java
+++ b/services/src/main/java/org/exoplatform/task/storage/impl/StatusStorageImpl.java
@@ -109,7 +109,7 @@ public class StatusStorageImpl implements StatusStorage {
     int maxRank = max != null && max.getRank() != null ? max.getRank() : -1;
 
     StatusHandler handler = daoHandler.getStatusHandler();
-    Status st = new Status(status, ++maxRank, StorageUtil.projectToEntity(project));
+    Status st = new Status(status, ++maxRank, project == null ? null : StorageUtil.getProjectEntityById(project.getId()));
     handler.create(st);
     return StorageUtil.statusToDTO(st,projectStorage);
   }
@@ -127,7 +127,7 @@ public class StatusStorageImpl implements StatusStorage {
       }
     }
     StatusHandler handler = daoHandler.getStatusHandler();
-    Status st = new Status(status, rank, StorageUtil.projectToEntity(project));
+    Status st = new Status(status, rank, project == null ? null : StorageUtil.getProjectEntityById(project.getId()));
     handler.create(st);
     return StorageUtil.statusToDTO(st,projectStorage);
   }

--- a/services/src/main/java/org/exoplatform/task/storage/impl/TaskStorageImpl.java
+++ b/services/src/main/java/org/exoplatform/task/storage/impl/TaskStorageImpl.java
@@ -17,15 +17,21 @@
 package org.exoplatform.task.storage.impl;
 
 import io.meeds.task.search.TaskSearchConnector;
+
+import lombok.SneakyThrows;
+
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.exoplatform.commons.utils.ListAccess;
+import org.exoplatform.container.component.RequestLifeCycle;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.task.dao.DAOHandler;
 import org.exoplatform.task.dao.OrderBy;
 import org.exoplatform.task.dao.TaskQuery;
 import org.exoplatform.task.domain.ChangeLog;
+import org.exoplatform.task.domain.Comment;
+import org.exoplatform.task.domain.LabelTaskMapping;
 import org.exoplatform.task.domain.Status;
 import org.exoplatform.task.domain.Task;
 import org.exoplatform.task.dto.ChangeLogEntry;
@@ -94,8 +100,27 @@ public class TaskStorageImpl implements TaskStorage {
     }
 
     @Override
+    @SneakyThrows
     public void delete(TaskDto task) {
-        daoHandler.getTaskHandler().delete(StorageUtil.taskToEntity(task));
+      long taskId = task.getId();
+      ListAccess<LabelTaskMapping> labels = daoHandler.getLabelTaskMappingHandler().findLabelMappings(taskId);
+      int labelsSize = labels == null ? 0 : labels.getSize();
+      if (labelsSize > 0) {
+        daoHandler.getLabelTaskMappingHandler().deleteAll(Arrays.asList(labels.load(0, labelsSize)));
+      }
+      ListAccess<Comment> comments = daoHandler.getCommentHandler().findComments(taskId);
+      int commentsSize = comments == null ? 0 : comments.getSize();
+      if (commentsSize > 0) {
+        daoHandler.getCommentHandler().deleteAll(Arrays.asList(comments.load(0, commentsSize)));
+      }
+      ListAccess<ChangeLog> logs = daoHandler.getTaskLogHandler().findTaskLogs(taskId);
+      int logsSize = logs == null ? 0 : logs.getSize();
+      if (logsSize > 0) {
+        daoHandler.getTaskLogHandler().deleteAll(Arrays.asList(logs.load(0, logsSize)));
+      }
+      RequestLifeCycle.restartTransaction();
+      Task taskEntity = daoHandler.getTaskHandler().find(taskId);
+      daoHandler.getTaskHandler().delete(taskEntity);
     }
 
     @Override

--- a/services/src/main/java/org/exoplatform/task/util/StorageUtil.java
+++ b/services/src/main/java/org/exoplatform/task/util/StorageUtil.java
@@ -27,6 +27,7 @@ import org.exoplatform.social.core.manager.IdentityManager;
 import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceService;
 import org.exoplatform.social.core.utils.MentionUtils;
+import org.exoplatform.task.dao.DAOHandler;
 import org.exoplatform.task.domain.*;
 import org.exoplatform.task.dto.*;
 import org.exoplatform.task.service.UserService;
@@ -74,11 +75,13 @@ public final class StorageUtil{
     }
 
     public static Task taskToEntity(TaskDto taskDto) {
-        if(taskDto==null){
-            return null;
+        if (taskDto == null) {
+          return null;
         }
-        Task taskEntity = new Task();
-        taskEntity.setId(taskDto.getId());
+        Task taskEntity = taskDto.getId() == 0 ? null : getTaskEntityById(taskDto.getId());
+        if (taskEntity == null) {
+          taskEntity = new Task();
+        }
         taskEntity.setTitle(taskDto.getTitle());
         taskEntity.setDescription(taskDto.getDescription());
         taskEntity.setPriority(taskDto.getPriority());
@@ -86,7 +89,9 @@ public final class StorageUtil{
         taskEntity.setAssignee(taskDto.getAssignee());
         taskEntity.setCoworker(taskDto.getCoworker());
         taskEntity.setWatcher(taskDto.getWatcher());
-        taskEntity.setStatus(statusToEntity(taskDto.getStatus()));
+        if (taskDto.getStatus() != null) {
+          taskEntity.setStatus(getStatusEntityById(taskDto.getStatus().getId()));
+        }
         taskEntity.setRank(taskDto.getRank());
         taskEntity.setActivityId(taskDto.getActivityId());
         taskEntity.setCompleted(taskDto.isCompleted());
@@ -98,12 +103,12 @@ public final class StorageUtil{
         return taskEntity;
     }
 
-    public static TaskDto taskToDto(Task taskEntity,ProjectStorage projectStorage) {
+    public static TaskDto taskToDto(Task taskEntity, ProjectStorage projectStorage) {
         if(taskEntity==null){
             return null;
         }
         TaskDto task = new TaskDto();
-        task.setId(taskEntity.getId());
+        task.setId(taskEntity.getId() == null ? 0l : taskEntity.getId());
         task.setTitle(taskEntity.getTitle());
         if(taskEntity.getDescription()!=null) {
             try {
@@ -129,16 +134,39 @@ public final class StorageUtil{
         return task;
     }
 
+    public static Status getStatusEntityById(Long statusId) {
+      return ExoContainerContext.getService(DAOHandler.class).getStatusHandler().find(statusId);
+    }
+
+    public static Project getProjectEntityById(Long projectId) {
+      return ExoContainerContext.getService(DAOHandler.class).getProjectHandler().find(projectId);
+    }
+
+    public static Label getLabelEntityById(Long labelId) {
+      return ExoContainerContext.getService(DAOHandler.class).getLabelHandler().find(labelId);
+    }
+
+    public static Comment getCommentEntityById(Long commentId) {
+      return ExoContainerContext.getService(DAOHandler.class).getCommentHandler().find(commentId);
+    }
+
+    public static Task getTaskEntityById(Long taskId) {
+      return ExoContainerContext.getService(DAOHandler.class).getTaskHandler().find(taskId);
+    }
 
     public static Status statusToEntity(StatusDto statusDto) {
         if(statusDto==null){
             return null;
         }
-        Status status = new Status();
-        status.setId(statusDto.getId());
+        Status status = statusDto.getId() == 0 ? null : getStatusEntityById(statusDto.getId());
+        if (status == null) {
+          status = new Status();
+        }
         status.setName(statusDto.getName());
         status.setRank(statusDto.getRank());
-        status.setProject(projectToEntity(statusDto.getProject()));
+        if (statusDto.getProject() != null) {
+          status.setProject(getProjectEntityById(statusDto.getProject().getId()));
+        }
         return status;
     }
 
@@ -160,19 +188,18 @@ public final class StorageUtil{
                 .collect(Collectors.toList());
     }
 
-    public static List<Status> listStatusToEntitys(List<StatusDto> status) {
-        return status.stream()
-                .map(StorageUtil::statusToEntity)
-                .collect(Collectors.toList());
-    }
-
-
     public static Project projectToEntity(ProjectDto projectDto) {
         if(projectDto==null){
             return null;
         }
-        Project project = new Project();
-        project.setId(projectDto.getId());
+        long projectId = projectDto.getId();
+        Project project = projectId == 0 ? null : getProjectEntityById(projectDto.getId());
+        if (project == null) {
+          project = new Project();
+        } else {
+          List<Status> statuses = ExoContainerContext.getService(DAOHandler.class).getStatusHandler().getStatuses(project.getId());
+          project.setStatus(new HashSet<>(statuses));
+        }
         project.setName(projectDto.getName());
         project.setDescription(projectDto.getDescription());
         project.setColor(projectDto.getColor());
@@ -180,11 +207,10 @@ public final class StorageUtil{
         project.setLastModifiedDate(projectDto.getLastModifiedDate());
         project.setParticipator(projectDto.getParticipator());
         project.setManager(projectDto.getManager());
-        project.setParent(projectToEntity(projectDto.getParent()));
-        //if(projectDto.getStatus()!=null)project.setStatus(projectDto.getStatus().stream().map(status -> statusToEntity(status)).collect(Collectors.toSet()));
-        //if(projectDto.getChildren()!=null)project.setChildren(projectDto.getChildren().stream().map(this::projectToEntity).collect(Collectors.toList()));
+        if (projectDto.getParent() != null) {
+          project.setParent(getProjectEntityById(projectDto.getParent().getId()));
+        }
         return project;
-
     }
 
     public static ProjectDto projectToDto(Project project, ProjectStorage projectStorage) {
@@ -224,17 +250,21 @@ public final class StorageUtil{
 
 
     public static Label labelToEntity(LabelDto labelDto) {
-        if(labelDto==null){
-            return null;
+        if (labelDto == null) {
+          return null;
         }
-        Label label = new Label();
-        label.setId(labelDto.getId());
+        Label label = labelDto.getId() == 0 ? null : getLabelEntityById(labelDto.getId());
+        if (label == null) {
+          label = new Label();
+        }
         label.setUsername(labelDto.getUsername());
-        label.setProject(projectToEntity(labelDto.getProject()));
+        if (labelDto.getProject() != null) {
+          label.setProject(getProjectEntityById(labelDto.getProject().getId()));
+        }
         label.setName(labelDto.getName());
         label.setColor(labelDto.getColor());
         label.setHidden(labelDto.isHidden());
-        label.setParent(labelToEntity(labelDto.getParent()));
+        label.setParent(labelDto.getParent() == null ? null : getLabelEntityById(labelDto.getParent().getId()));
         return label;
     }
 
@@ -292,13 +322,18 @@ public final class StorageUtil{
         if(labelDto==null){
             return null;
         }
-        Label label = new Label();
-        label.setId(labelDto.getId());
+        Label label = labelDto.getId() == 0 ? null : getLabelEntityById(labelDto.getId());
+        if (label == null) {
+          label = new Label();
+        }
         label.setUsername(labelDto.getUsername());
         label.setName(labelDto.getName());
         label.setColor(labelDto.getColor());
         label.setHidden(labelDto.isHidden());
-        label.setParent(labelToEntity(labelDto.getParent()));
+        label.setParent(labelDto.getParent() == null ? null : getLabelEntityById(labelDto.getParent().getId()));
+        if (labelDto.getProject() != null) {
+          label.setProject(getProjectEntityById(labelDto.getProject().getId()));
+        }
         return label;
     }
 
@@ -306,16 +341,19 @@ public final class StorageUtil{
         if(commentDto==null){
             return null;
         }
-        Comment commentEntity = new Comment();
-        commentEntity.setId(commentDto.getId());
+        Comment commentEntity = commentDto.getId() == 0 ? null : getCommentEntityById(commentDto.getId());
+        if (commentEntity == null) {
+          commentEntity = new Comment();
+        }
         commentEntity.setAuthor(commentDto.getAuthor());
         commentEntity.setComment(commentDto.getComment());
-        if (commentDto.getParentComment()!=null) commentEntity.setParentComment(commentToEntity(commentDto.getParentComment()));
+        if (commentDto.getParentComment() != null) {
+          commentEntity.setParentComment(getCommentEntityById(commentDto.getParentComment().getId()));
+        }
         commentEntity.setCreatedTime(commentDto.getCreatedTime());
 
-        TaskDto task = commentDto.getTask();
-        commentEntity.setTask(taskToEntity(task));
-        commentEntity.setMentionedUsers(processMentions(task, commentDto.getComment()));
+        commentEntity.setTask(getTaskEntityById(commentDto.getTask().getId()));
+        commentEntity.setMentionedUsers(processMentions(commentDto.getTask(), commentDto.getComment()));
         return commentEntity;
     }
 
@@ -324,7 +362,7 @@ public final class StorageUtil{
             return null;
         }
         CommentDto commentDto = new CommentDto();
-        commentDto.setId(comment.getId());
+        commentDto.setId(comment.getId() == null ? 0 :comment.getId());
         commentDto.setAuthor(comment.getAuthor());
         commentDto.setComment(comment.getComment());
         if (comment.getParentComment() != null) {

--- a/services/src/main/java/org/exoplatform/task/util/TaskUtil.java
+++ b/services/src/main/java/org/exoplatform/task/util/TaskUtil.java
@@ -802,11 +802,14 @@ public final class TaskUtil {
   }
 
   public static void broadcastEvent(ListenerService listenerService, String eventName, Object source, Object data) {
-    try {
-      listenerService.broadcast(eventName, source, data);
-    } catch (Exception var5) {
-      LOG.warn("Error broadcasting event '" + eventName + "' using source '" + source + "' and data " + data, var5);
+    if (listenerService != null) {
+      try {
+        listenerService.broadcast(eventName, source, data);
+      } catch (Exception var5) {
+        LOG.warn("Error broadcasting event '" + eventName + "' using source '" + source + "' and data " + data, var5);
+      }
     }
   }
+
 }
 

--- a/services/src/main/resources/jpa-entities.idx
+++ b/services/src/main/resources/jpa-entities.idx
@@ -1,8 +1,8 @@
-org.exoplatform.task.domain.Task
-org.exoplatform.task.domain.Status
-org.exoplatform.task.domain.UserSetting
-org.exoplatform.task.domain.Comment
-org.exoplatform.task.domain.Project
 org.exoplatform.task.domain.Label
+org.exoplatform.task.domain.UserSetting
+org.exoplatform.task.domain.Status
 org.exoplatform.task.domain.LabelTaskMapping
 org.exoplatform.task.domain.ChangeLog
+org.exoplatform.task.domain.Task
+org.exoplatform.task.domain.Project
+org.exoplatform.task.domain.Comment

--- a/services/src/test/java/org/exoplatform/task/AbstractTest.java
+++ b/services/src/test/java/org/exoplatform/task/AbstractTest.java
@@ -16,16 +16,12 @@
  */
 package org.exoplatform.task;
 
-import java.sql.SQLException;
-
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.BeforeClass;
 
-import org.exoplatform.commons.persistence.impl.EntityManagerService;
 import org.exoplatform.container.PortalContainer;
 import org.exoplatform.container.component.RequestLifeCycle;
+import org.exoplatform.task.dao.DAOHandler;
 
 /**
  * A base test class for all DAO tests which take responsibility to
@@ -38,27 +34,23 @@ public class AbstractTest {
 
   @Before
   public void initializeContainerAndStartRequestLifecycle() {
-    PortalContainer container = PortalContainer.getInstance();
-
-    //
-    RequestLifeCycle.begin(container);
-    
-    EntityManagerService entityMgrService = (EntityManagerService) container.getComponentInstanceOfType(EntityManagerService.class);
-    entityMgrService.getEntityManager().getTransaction().begin();
+    RequestLifeCycle.begin(PortalContainer.getInstance());
   }
 
   @After
   public void endRequestLifecycle() {
-    PortalContainer container = PortalContainer.getInstance();
-
-    //
-    EntityManagerService entityMgrService = (EntityManagerService) container.getComponentInstanceOfType(EntityManagerService.class);
-    if (entityMgrService.getEntityManager() != null && entityMgrService.getEntityManager().getTransaction() != null
-        && entityMgrService.getEntityManager().getTransaction().isActive()) {
-      entityMgrService.getEntityManager().getTransaction().commit();
-      //
-      RequestLifeCycle.end();
-    }
-
+    RequestLifeCycle.end();
   }
+
+  protected void deleteAll() {
+    RequestLifeCycle.restartTransaction();
+    DAOHandler daoHandler = PortalContainer.getInstance().getComponentInstanceOfType(DAOHandler.class);
+    daoHandler.getLabelHandler().deleteAll();
+    RequestLifeCycle.restartTransaction();
+    daoHandler.getCommentHandler().deleteAll();
+    daoHandler.getTaskHandler().deleteAll();
+    daoHandler.getProjectHandler().deleteAll();
+    daoHandler.getStatusHandler().deleteAll();
+  }
+
 }

--- a/services/src/test/java/org/exoplatform/task/dao/TestCommentDAO.java
+++ b/services/src/test/java/org/exoplatform/task/dao/TestCommentDAO.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 import org.exoplatform.commons.utils.ListAccess;
 import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.container.PortalContainer;
+import org.exoplatform.container.component.RequestLifeCycle;
 import org.exoplatform.task.AbstractTest;
 import org.exoplatform.task.domain.Comment;
 import org.exoplatform.task.domain.Task;
@@ -57,9 +58,7 @@ public class TestCommentDAO extends AbstractTest {
 
   @After
   public void cleanData() {
-    endRequestLifecycle();
-    commentDAO.deleteAll();
-    taskDAO.deleteAll();
+    deleteAll();
   }
 
   @Test

--- a/services/src/test/java/org/exoplatform/task/dao/TestCommentDAO.java
+++ b/services/src/test/java/org/exoplatform/task/dao/TestCommentDAO.java
@@ -78,7 +78,12 @@ public class TestCommentDAO extends AbstractTest {
     comment = comments[0];
     Assert.assertEquals(username, comment.getAuthor());
 
-    //Assert.assertEquals(task.getId(), comment.getTask().getId());
+    taskDAO.update(task);
+    listComments = commentDAO.findComments(task.getId());
+    comments = ListUtil.load(listComments, 0, -1);
+    Assert.assertEquals(1, comments.length);
+    comment = comments[0];
+    Assert.assertEquals(username, comment.getAuthor());
   }
 
   @Test

--- a/services/src/test/java/org/exoplatform/task/dao/TestLabelDAO.java
+++ b/services/src/test/java/org/exoplatform/task/dao/TestLabelDAO.java
@@ -45,8 +45,7 @@ public class TestLabelDAO extends AbstractTest {
 
   @After
   public void tearDown() {
-    taskService.getLabelTaskMappingHandler().deleteAll();
-    lblDAO.deleteAll();
+    deleteAll();
   }
   
   @Test

--- a/services/src/test/java/org/exoplatform/task/dao/TestProjectDAO.java
+++ b/services/src/test/java/org/exoplatform/task/dao/TestProjectDAO.java
@@ -27,6 +27,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.exoplatform.commons.utils.ListAccess;
 import org.exoplatform.container.PortalContainer;
+import org.exoplatform.container.component.RequestLifeCycle;
 import org.exoplatform.task.domain.Project;
 import org.exoplatform.task.AbstractTest;
 
@@ -49,7 +50,7 @@ public class TestProjectDAO extends AbstractTest {
 
   @After
   public void tearDown() {
-    pDAO.deleteAll();
+    deleteAll();
   }
 
   @Test

--- a/services/src/test/java/org/exoplatform/task/dao/TestStatusDAO.java
+++ b/services/src/test/java/org/exoplatform/task/dao/TestStatusDAO.java
@@ -20,6 +20,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.exoplatform.container.PortalContainer;
+import org.exoplatform.container.component.RequestLifeCycle;
 import org.exoplatform.task.AbstractTest;
 import org.exoplatform.task.domain.Project;
 import org.exoplatform.task.domain.Status;
@@ -48,7 +49,7 @@ public class TestStatusDAO extends AbstractTest {
 
   @After
   public void tearDown() {
-    sDAO.deleteAll();
+    deleteAll();
   }
 
   @Test
@@ -96,21 +97,21 @@ public class TestStatusDAO extends AbstractTest {
       t.setTitle("testTitle");
       t.setStatus(s2);
       tDAO.create(t);
-      
-      endRequestLifecycle();
-      initializeContainerAndStartRequestLifecycle();    
-      
+
+      RequestLifeCycle.restartTransaction();
+
       StatusHandler handler = daoHandler.getStatusHandler();
       Status st = handler.find(s2.getId());      
       //
       daoHandler.getTaskHandler().updateStatus(st, s1);
-      
+      RequestLifeCycle.restartTransaction();
+
+      st = handler.find(s2.getId());
       st.setProject(null);
       handler.delete(st);
-      
-      endRequestLifecycle();
-      initializeContainerAndStartRequestLifecycle();
-      
+
+      RequestLifeCycle.restartTransaction();
+
       t = tDAO.find(t.getId());
       Assert.assertNotNull(t);
       Assert.assertEquals(s1.getName(), t.getStatus().getName());

--- a/services/src/test/java/org/exoplatform/task/dao/TestTaskDAO.java
+++ b/services/src/test/java/org/exoplatform/task/dao/TestTaskDAO.java
@@ -77,11 +77,13 @@ public class TestTaskDAO extends AbstractTest {
   public void setup() {
     PortalContainer container = PortalContainer.getInstance();
 
-    daoHandler = (DAOHandler) container.getComponentInstanceOfType(DAOHandler.class);
+    daoHandler = container.getComponentInstanceOfType(DAOHandler.class);
     tDAO = daoHandler.getTaskHandler();
     cDAO = daoHandler.getCommentHandler();
     labelHandler = daoHandler.getLabelHandler();
     taskSearchConnector = container.getComponentInstanceOfType(TaskSearchConnector.class);
+    projectStorage = container.getComponentInstanceOfType(ProjectStorage.class);
+    userService = container.getComponentInstanceOfType(UserService.class);
     taskStorage = new TaskStorageImpl(daoHandler, userService, projectStorage, taskSearchConnector);
     taskService = new TaskServiceImpl(taskStorage, daoHandler, listenerService);
   }
@@ -231,7 +233,7 @@ public class TestTaskDAO extends AbstractTest {
     tDAO.create(task);
 
     TaskQuery query = new TaskQuery();
-    query.setEmptyField("lblMapping");
+    query.setEmptyField("labels");
     ListAccess<Task> tasks = tDAO.findTasks(query);
     Assert.assertEquals(1, tasks.getSize());
     
@@ -405,7 +407,7 @@ public class TestTaskDAO extends AbstractTest {
     //
     endRequestLifecycle();
     initializeContainerAndStartRequestLifecycle();
-    tDAO.delete(tDAO.find(task.getId()));
+    taskStorage.delete(taskStorage.getTaskById(task.getId()));
     labels = labelHandler.findLabelsByTask(task.getId(), project.getId());
     Assert.assertEquals(0, labels.getSize());
   }

--- a/services/src/test/java/org/exoplatform/task/dao/TestTaskDAO.java
+++ b/services/src/test/java/org/exoplatform/task/dao/TestTaskDAO.java
@@ -18,6 +18,7 @@ package org.exoplatform.task.dao;
 
 import org.exoplatform.commons.utils.ListAccess;
 import org.exoplatform.container.PortalContainer;
+import org.exoplatform.container.component.RequestLifeCycle;
 import org.exoplatform.services.listener.ListenerService;
 import org.exoplatform.services.security.ConversationState;
 import org.exoplatform.services.security.Identity;
@@ -87,15 +88,7 @@ public class TestTaskDAO extends AbstractTest {
 
   @After
   public void tearDown() {
-    for (Task t : tDAO.findAll()) {
-      t.setStatus(null);
-    }    
-    tDAO.updateAll(tDAO.findAll());
-    daoHandler.getLabelTaskMappingHandler().deleteAll();
-    daoHandler.getTaskLogHandler().deleteAll();
-    cDAO.deleteAll();
-    tDAO.deleteAll();
-    labelHandler.deleteAll();
+    deleteAll();
   }
 
   @Test
@@ -579,9 +572,11 @@ public class TestTaskDAO extends AbstractTest {
 
     coworkers.add("worker2");
     task.setCoworker(coworkers);
+    tDAO.update(task);
+
     //worker2 is now a coworker, so he has permission
     ConversationState.setCurrent(new ConversationState(worker2));
-    Assert.assertEquals(true, TaskUtil.hasEditPermission(taskService,task));
+    Assert.assertEquals(true, TaskUtil.hasEditPermission(taskService, task));
   }
 
   @Test

--- a/services/src/test/java/org/exoplatform/task/rest/TestProjectRestService.java
+++ b/services/src/test/java/org/exoplatform/task/rest/TestProjectRestService.java
@@ -574,7 +574,7 @@ public class TestProjectRestService {
     when(projectService.getProject(projectDto.getId())).thenReturn(projectDto);
 
     Response response1 = projectRestService.deleteProject(projectDto.getId(), false, 0, 0);
-    assertEquals(Response.Status.OK.getStatusCode(), response1.getStatus());
+    assertEquals(Response.Status.NO_CONTENT.getStatusCode(), response1.getStatus());
   }
 
   @Test

--- a/services/src/test/java/org/exoplatform/task/security/TestPermission.java
+++ b/services/src/test/java/org/exoplatform/task/security/TestPermission.java
@@ -64,9 +64,7 @@ public class TestPermission extends AbstractTest {
 
   @After
   public void tearDown() {
-    tDAO.deleteAll();
-    daoHandler.getStatusHandler().deleteAll();
-    pDAO.deleteAll();
+    deleteAll();
   }
 
   @Test

--- a/services/src/test/java/org/exoplatform/task/service/CommentServiceTest.java
+++ b/services/src/test/java/org/exoplatform/task/service/CommentServiceTest.java
@@ -16,8 +16,7 @@
  */
 package org.exoplatform.task.service;
 
-import org.exoplatform.container.ExoContainer;
-
+import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.container.PortalContainer;
 import org.exoplatform.services.listener.ListenerService;
 import org.exoplatform.task.TestUtils;
@@ -40,15 +39,19 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Date;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class CommentServiceTest {
+
+  MockedStatic<ExoContainerContext> containerContext;
 
   StatusService           statusService;
 
@@ -64,10 +67,10 @@ public class CommentServiceTest {
   ListenerService         listenerService;
 
   @Mock
-  ExoContainer container;
+  TaskHandler             taskHandler;
 
   @Mock
-  TaskHandler             taskHandler;
+  ProjectHandler          projectHandler;
 
   @Mock
   StatusHandler           statusHandler;
@@ -90,31 +93,57 @@ public class CommentServiceTest {
   @Captor
   ArgumentCaptor<Comment> commentCaptor;
 
+  PortalContainer                   container;
+
   @Before
   public void setUp() {
     // Make sure the container is started to prevent the ExoTransactional annotation
     // to fail
-    PortalContainer.getInstance();
-    PortalContainer.getInstance();
+    container = PortalContainer.getInstance();
     commentStorage = new CommentStorageImpl(daoHandler,projectStorage);
     commentService = new CommentServiceImpl(commentStorage, listenerService);
+
+    containerContext = mockStatic(ExoContainerContext.class);
+    containerContext.when(() -> ExoContainerContext.getService(any())).thenAnswer(invocation -> {
+      Class<?> clazz = invocation.getArgument(0, Class.class);
+      if (clazz.equals(DAOHandler.class)) {
+        return daoHandler;
+      } else {
+        return container.getComponentInstanceOfType(clazz);
+      }
+    });
+
     // Mock DAO handler to return Mocked DAO
     when(daoHandler.getCommentHandler()).thenReturn(commentHandler);
+    when(daoHandler.getTaskHandler()).thenReturn(taskHandler);
+    when(daoHandler.getStatusHandler()).thenReturn(statusHandler);
+    when(daoHandler.getProjectHandler()).thenReturn(projectHandler);
 
     // Mock some DAO methods
     when(commentHandler.find(TestUtils.EXISTING_COMMENT_ID)).thenReturn(TestUtils.getDefaultComment());
+    when(taskHandler.find(TestUtils.EXISTING_TASK_ID)).thenReturn(TestUtils.getDefaultTask());
+    lenient().when(commentHandler.create(any())).thenAnswer(invocation -> {
+      long id = (long) (Math.random() * Long.MAX_VALUE); // NOSONAR
+      Comment c = invocation.getArgument(0, Comment.class);
+      c.setId(id);
+      when(commentHandler.find(id)).thenReturn(c);
+      return c;
+    });
   }
 
   @After
   public void tearDown() {
     commentService = null;
+    containerContext.close();
+    containerContext = null;
   }
 
-  @Test public void testAddComment() throws EntityNotFoundException { Comment
-          comment = TestUtils.getDefaultComment();
-    when(daoHandler.getCommentHandler().create(any())).thenReturn(comment);
-    commentService.addComment(StorageUtil.taskToDto(comment.getTask(),projectStorage),comment.
-            getAuthor(),comment.getComment());
+  @Test
+  public void testAddComment() throws EntityNotFoundException {
+    Comment comment = TestUtils.getDefaultComment();
+    commentService.addComment(StorageUtil.taskToDto(comment.getTask(), projectStorage),
+                              comment.getAuthor(),
+                              comment.getComment());
     verify(commentHandler, times(1)).create(commentCaptor.capture());
     Comment result = commentCaptor.getValue();
     assertEquals("Bla bla", result.getComment());
@@ -128,32 +157,27 @@ public class CommentServiceTest {
     commentService.removeComment(TestUtils.EXISTING_COMMENT_ID);
     verify(commentHandler, times(1)).delete(commentCaptor.capture());
 
-    assertEquals(TestUtils.EXISTING_COMMENT_ID, commentCaptor.getValue().getId());
+    assertEquals(TestUtils.EXISTING_COMMENT_ID, commentCaptor.getValue().getId().longValue());
 
   }
 
   @Test
-  public void testGetComment() {
-    Comment comment = TestUtils.getDefaultComment();
-    commentService.getComment(TestUtils.EXISTING_COMMENT_ID);
-
-  }
-
-  @Test public void testAddCommentsByTask() throws EntityNotFoundException {
-    String username = "Tib"; String comment = "Bla bla bla bla bla";
-   CommentDto newComment = TestUtils.getDefaultCommentDto();
+  public void testAddCommentsByTask() throws EntityNotFoundException {
+    String username = "Tib";
+    CommentDto newComment = TestUtils.getDefaultCommentDto();
     commentService.addComment(TestUtils.getDefaultTaskDto(), newComment.getAuthor(), newComment.getComment());
-    commentService.getComments(TestUtils.EXISTING_TASK_ID,0,1);
+    commentService.getComments(TestUtils.EXISTING_TASK_ID, 0, 1);
     commentService.countComments(TestUtils.EXISTING_TASK_ID);
     verify(commentHandler, times(1)).create(commentCaptor.capture());
-    assertEquals(TestUtils.EXISTING_TASK_ID, commentCaptor.getValue().getTask().getId());
+    assertEquals(TestUtils.EXISTING_TASK_ID, commentCaptor.getValue().getTask().getId().longValue());
     assertEquals(username, commentCaptor.getValue().getAuthor());
     assertEquals(newComment.getComment(), commentCaptor.getValue().getComment());
-
   }
 
-  @Test public void testAddSubComments() throws EntityNotFoundException {
-    String username = "Tib"; String comment = "Bla bla bla bla bla";
+  @Test
+  public void testAddSubComments() throws EntityNotFoundException {
+    String username = "Tib";
+    String comment = "Bla bla bla bla bla";
     String authorSubComment = "Tib2";
     String subCommentContent = "Bla bla bla bla bla sub comment";
     CommentDto newComment = new CommentDto();
@@ -161,20 +185,24 @@ public class CommentServiceTest {
     newComment.setAuthor(username);
     newComment.setComment(comment);
     newComment.setCreatedTime(new Date());
-    UserSettingDto userSettingDto= TestUtils.getDefaultUserSettingDto();
-    assertEquals ("user",userSettingDto.getUsername());
-    assertEquals (true,userSettingDto.isShowHiddenLabel());
-    assertEquals (true,userSettingDto.isShowHiddenProject());
-    commentService.addComment(StorageUtil.taskToDto(TestUtils.getDefaultTask(),projectStorage), username, comment);
+    UserSettingDto userSettingDto = TestUtils.getDefaultUserSettingDto();
+    assertEquals("user", userSettingDto.getUsername());
+    assertEquals(true, userSettingDto.isShowHiddenLabel());
+    assertEquals(true, userSettingDto.isShowHiddenProject());
+    commentService.addComment(StorageUtil.taskToDto(TestUtils.getDefaultTask(), projectStorage), username, comment);
     verify(commentHandler, times(1)).create(commentCaptor.capture());
     Comment parentComment = commentCaptor.getValue();
-    assertEquals(TestUtils.EXISTING_TASK_ID, parentComment.getTask().getId());
+    assertEquals(TestUtils.EXISTING_TASK_ID, parentComment.getTask().getId().longValue());
     assertEquals(username, parentComment.getAuthor());
     assertEquals(comment, parentComment.getComment());
     long parentCommentId = parentComment.getId();
-    commentService.addComment(StorageUtil.taskToDto(TestUtils.getDefaultTask(),projectStorage), parentCommentId ,authorSubComment, subCommentContent);
+    commentService.addComment(StorageUtil.taskToDto(TestUtils.getDefaultTask(), projectStorage),
+                              parentCommentId,
+                              authorSubComment,
+                              subCommentContent);
     verify(commentHandler, times(2)).create(commentCaptor.capture());
-    Comment subComment = commentCaptor.getValue(); assertEquals(TestUtils.EXISTING_TASK_ID, subComment.getTask().getId());
+    Comment subComment = commentCaptor.getValue();
+    assertEquals(TestUtils.EXISTING_TASK_ID, subComment.getTask().getId().longValue());
     assertEquals(authorSubComment, subComment.getAuthor());
     assertEquals(subCommentContent, subComment.getComment());
   }

--- a/services/src/test/java/org/exoplatform/task/service/LabelServiceTest.java
+++ b/services/src/test/java/org/exoplatform/task/service/LabelServiceTest.java
@@ -16,6 +16,27 @@
  */
 package org.exoplatform.task.service;
 
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.MockitoJUnitRunner;
+
 import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.container.PortalContainer;
 import org.exoplatform.services.listener.ListenerService;
@@ -38,24 +59,10 @@ import org.exoplatform.task.storage.impl.LabelStorageImpl;
 import org.exoplatform.task.storage.impl.ProjectStorageImpl;
 import org.exoplatform.task.storage.impl.StatusStorageImpl;
 import org.exoplatform.task.storage.impl.TaskStorageImpl;
-import io.meeds.task.search.TaskSearchConnector;
 import org.exoplatform.task.util.StorageUtil;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
-import org.mockito.Mock;
-import org.mockito.MockedStatic;
-import org.mockito.junit.MockitoJUnitRunner;
 
-import java.util.Arrays;
-import java.util.Collections;
-
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.*;
+import io.meeds.task.domain.LabelField;
+import io.meeds.task.search.TaskSearchConnector;
 
 @RunWith(MockitoJUnitRunner.Silent.class)
 public class LabelServiceTest {
@@ -106,7 +113,7 @@ public class LabelServiceTest {
         PortalContainer container = PortalContainer.getInstance();
         projectStorage = new ProjectStorageImpl(daoHandler);
         taskStorage = new TaskStorageImpl(daoHandler,userService,projectStorage, taskSearchConnector);
-        statusStorage = new StatusStorageImpl(daoHandler, projectStorage);
+        statusStorage = new StatusStorageImpl(daoHandler, taskStorage, projectStorage);
         statusService = new StatusServiceImpl(daoHandler, statusStorage, projectStorage, listenerService);
         labelStorage = new LabelStorageImpl(daoHandler);
         labelService = new LabelServiceImpl(labelStorage, daoHandler, projectStorage, listenerService);
@@ -167,7 +174,7 @@ public class LabelServiceTest {
         label.setName("exo");
         Label labelEntity = StorageUtil.labelToEntity(label);
         when(daoHandler.getLabelHandler().update(any())).thenReturn(labelEntity);
-        labelService.updateLabel(label, Arrays.asList(Label.FIELDS.NAME));
+        labelService.updateLabel(label, Arrays.asList(LabelField.NAME));
         verify(labelHandler, times(1)).update(labelCaptor.capture());
 
         assertEquals("exo", labelCaptor.getValue().getName());
@@ -181,7 +188,7 @@ public class LabelServiceTest {
         label.setColor("white");
         Label labelEntity = StorageUtil.labelToEntity(label);
         when(daoHandler.getLabelHandler().update(any())).thenReturn(labelEntity);
-        labelService.updateLabel(label, Arrays.asList(Label.FIELDS.COLOR));
+        labelService.updateLabel(label, Arrays.asList(LabelField.COLOR));
         verify(labelHandler, times(1)).update(labelCaptor.capture());
 
         assertEquals("white", labelCaptor.getValue().getColor());
@@ -200,7 +207,7 @@ public class LabelServiceTest {
         label.setId(labelId);
         when(daoHandler.getLabelHandler().find(labelId)).thenReturn(label);
         when(daoHandler.getLabelHandler().update(argThat(l -> l.getId() == labelId))).thenReturn(label);
-        labelService.updateLabel(labelDto, Collections.singletonList(Label.FIELDS.PARENT));
+        labelService.updateLabel(labelDto, Collections.singletonList(LabelField.PARENT));
         verify(labelHandler, times(1)).update(labelCaptor.capture());
 
         assertEquals(labelDto.getParent(), StorageUtil.labelToDto(labelCaptor.getValue().getParent()));
@@ -214,7 +221,7 @@ public class LabelServiceTest {
         label.setHidden(true);
         Label labelEntity = StorageUtil.labelToEntity(label);
         when(daoHandler.getLabelHandler().update(any())).thenReturn(labelEntity);
-        labelService.updateLabel(label, Arrays.asList(Label.FIELDS.HIDDEN));
+        labelService.updateLabel(label, Arrays.asList(LabelField.HIDDEN));
         verify(labelHandler, times(1)).update(labelCaptor.capture());
 
         assertEquals(true, labelCaptor.getValue().isHidden());

--- a/services/src/test/java/org/exoplatform/task/service/LabelServiceTest.java
+++ b/services/src/test/java/org/exoplatform/task/service/LabelServiceTest.java
@@ -16,6 +16,7 @@
  */
 package org.exoplatform.task.service;
 
+import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.container.PortalContainer;
 import org.exoplatform.services.listener.ListenerService;
 import org.exoplatform.task.TestUtils;
@@ -46,7 +47,8 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.MockedStatic;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -55,8 +57,10 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class LabelServiceTest {
+
+  MockedStatic<ExoContainerContext> containerContext;
 
   StatusService         statusService;
 
@@ -99,7 +103,7 @@ public class LabelServiceTest {
     public void setUp() {
         // Make sure the container is started to prevent the ExoTransactional annotation
         // to fail
-        PortalContainer.getInstance();
+        PortalContainer container = PortalContainer.getInstance();
         projectStorage = new ProjectStorageImpl(daoHandler);
         taskStorage = new TaskStorageImpl(daoHandler,userService,projectStorage, taskSearchConnector);
         statusStorage = new StatusStorageImpl(daoHandler, projectStorage);
@@ -107,22 +111,37 @@ public class LabelServiceTest {
         labelStorage = new LabelStorageImpl(daoHandler);
         labelService = new LabelServiceImpl(labelStorage, daoHandler, projectStorage, listenerService);
         taskService = new TaskServiceImpl(taskStorage, daoHandler, listenerService);
+        
         // Mock DAO handler to return Mocked DAO
         when(daoHandler.getLabelHandler()).thenReturn(labelHandler);
+        containerContext = mockStatic(ExoContainerContext.class);
+        containerContext.when(() -> ExoContainerContext.getService(any())).thenAnswer(invocation -> {
+          Class<?> clazz = invocation.getArgument(0, Class.class);
+          if (clazz.equals(DAOHandler.class)) {
+            return daoHandler;
+          } else {
+            return container.getComponentInstanceOfType(clazz);
+          }
+        });
 
         // Mock some DAO methods
-        when(labelHandler.find(TestUtils.EXISTING_LABEL_ID)).thenReturn(StorageUtil.labelToEntity(TestUtils.getDefaultLabel()));
-    }
+        Label label = StorageUtil.labelToEntity(TestUtils.getDefaultLabel());
+        label.setId(TestUtils.EXISTING_LABEL_ID);
+        when(labelHandler.find(TestUtils.EXISTING_LABEL_ID)).thenReturn(label);
+      }
 
     @After
     public void tearDown() {
-        labelService = null;
+      labelService = null;
+      containerContext.close();
+      containerContext = null;
     }
 
     @Test
     public void testCreateDefaultLabelTask() {
         LabelDto label = TestUtils.getDefaultLabel();
-        when(daoHandler.getLabelHandler().create(any())).thenReturn(StorageUtil.labelToEntity(label));
+        Label labelEntity = StorageUtil.labelToEntity(label);
+        when(daoHandler.getLabelHandler().create(any())).thenReturn(labelEntity);
         labelService.createLabel(label);
         verify(labelHandler, times(1)).create(labelCaptor.capture());
         Label result = labelCaptor.getValue();
@@ -146,7 +165,8 @@ public class LabelServiceTest {
         LabelDto label = labelService.getLabel(TestUtils.EXISTING_LABEL_ID);
         label.setId(TestUtils.EXISTING_LABEL_ID);
         label.setName("exo");
-        when(daoHandler.getLabelHandler().update(any())).thenReturn(StorageUtil.labelToEntity(label));
+        Label labelEntity = StorageUtil.labelToEntity(label);
+        when(daoHandler.getLabelHandler().update(any())).thenReturn(labelEntity);
         labelService.updateLabel(label, Arrays.asList(Label.FIELDS.NAME));
         verify(labelHandler, times(1)).update(labelCaptor.capture());
 
@@ -159,7 +179,8 @@ public class LabelServiceTest {
         LabelDto label = labelService.getLabel(TestUtils.EXISTING_LABEL_ID);
         label.setId(TestUtils.EXISTING_LABEL_ID);
         label.setColor("white");
-        when(daoHandler.getLabelHandler().update(any())).thenReturn(StorageUtil.labelToEntity(label));
+        Label labelEntity = StorageUtil.labelToEntity(label);
+        when(daoHandler.getLabelHandler().update(any())).thenReturn(labelEntity);
         labelService.updateLabel(label, Arrays.asList(Label.FIELDS.COLOR));
         verify(labelHandler, times(1)).update(labelCaptor.capture());
 
@@ -167,20 +188,22 @@ public class LabelServiceTest {
     }
 
     @Test
-    public void testUpdateLabelPARENT() throws EntityNotFoundException {
+    public void testUpdateLabelParent() throws EntityNotFoundException {
         LabelDto parentLabel = labelService.getLabel(TestUtils.EXISTING_LABEL_ID);
-        LabelDto label = new LabelDto();
+        LabelDto labelDto = new LabelDto();
         long labelId = 5;
+        labelDto.setId(labelId);
+        labelDto.setUsername("root");
+        labelDto.setName("testLabel");
+        labelDto.setParent(parentLabel);
+        Label label = StorageUtil.labelToEntity(labelDto);
         label.setId(labelId);
-        label.setUsername("root");
-        label.setName("testLabel");
-        label.setParent(parentLabel);
-        when(daoHandler.getLabelHandler().find(labelId)).thenReturn(StorageUtil.labelToEntity(label));
-        when(daoHandler.getLabelHandler().update(any())).thenReturn(StorageUtil.labelToEntity(label));
-        labelService.updateLabel(label, Collections.singletonList(Label.FIELDS.PARENT));
+        when(daoHandler.getLabelHandler().find(labelId)).thenReturn(label);
+        when(daoHandler.getLabelHandler().update(argThat(l -> l.getId() == labelId))).thenReturn(label);
+        labelService.updateLabel(labelDto, Collections.singletonList(Label.FIELDS.PARENT));
         verify(labelHandler, times(1)).update(labelCaptor.capture());
 
-        assertEquals(label.getParent(), StorageUtil.labelToDto(labelCaptor.getValue().getParent()));
+        assertEquals(labelDto.getParent(), StorageUtil.labelToDto(labelCaptor.getValue().getParent()));
     }
 
     @Test
@@ -189,7 +212,8 @@ public class LabelServiceTest {
         LabelDto label = labelService.getLabel(TestUtils.EXISTING_LABEL_ID);
         label.setId(TestUtils.EXISTING_LABEL_ID);
         label.setHidden(true);
-        when(daoHandler.getLabelHandler().update(any())).thenReturn(StorageUtil.labelToEntity(label));
+        Label labelEntity = StorageUtil.labelToEntity(label);
+        when(daoHandler.getLabelHandler().update(any())).thenReturn(labelEntity);
         labelService.updateLabel(label, Arrays.asList(Label.FIELDS.HIDDEN));
         verify(labelHandler, times(1)).update(labelCaptor.capture());
 

--- a/services/src/test/java/org/exoplatform/task/service/ProjectServiceTest.java
+++ b/services/src/test/java/org/exoplatform/task/service/ProjectServiceTest.java
@@ -105,12 +105,14 @@ public class ProjectServiceTest {
     @Before
     public void setUp() {
         // Make sure the container is started to prevent the ExoTransactional annotation to fail
-        PortalContainer.getInstance();
+        PortalContainer container = PortalContainer.getInstance();
         projectStorage = new ProjectStorageImpl(daoHandler);
-        statusStorage = new StatusStorageImpl(daoHandler, projectStorage);
+        taskStorage = container.getComponentInstanceOfType(TaskStorage.class);
+        statusStorage = new StatusStorageImpl(daoHandler, taskStorage, projectStorage);
         projectService = new ProjectServiceImpl(statusService, taskService, daoHandler, projectStorage, listenerService);
         //Mock DAO handler to return Mocked DAO
         when(daoHandler.getProjectHandler()).thenReturn(projectHandler);
+        when(daoHandler.getStatusHandler()).thenReturn(statusHandler);
 
         //Mock some DAO methods
         when(projectHandler.create(any(Project.class))).thenReturn(TestUtils.getDefaultProject());

--- a/services/src/test/java/org/exoplatform/task/service/ProjectServiceTest.java
+++ b/services/src/test/java/org/exoplatform/task/service/ProjectServiceTest.java
@@ -149,15 +149,16 @@ public class ProjectServiceTest {
 
     @Test
     public void testCreateDefaultProject() throws EntityNotFoundException {
-
         ProjectDto defaultProject = TestDtoUtils.getDefaultProject();
         Long projectParent = TestUtils.EXISTING_PROJECT_ID;
-        //when(projectStorage.getProject(projectParent).getManager()).thenReturn(TestDtoUtils.getParentProject().getManager());
+        when(projectHandler.create(any())).thenAnswer(invocation -> {
+          Project p = invocation.getArgument(0, Project.class);
+          p.setId(projectParent);
+          return p;
+        });
         projectService.createProject(defaultProject, projectParent);
         verify(projectHandler, times(1)).create(projectCaptor.capture());
-
-        assertEquals(projectParent, new Long(projectCaptor.getValue().getParent().getId()));
-
+        assertEquals(projectParent.longValue(), projectCaptor.getValue().getId());
     }
 
     @Test

--- a/services/src/test/java/org/exoplatform/task/service/StatusServiceTest.java
+++ b/services/src/test/java/org/exoplatform/task/service/StatusServiceTest.java
@@ -16,17 +16,43 @@
  */
 package org.exoplatform.task.service;
 
-import org.exoplatform.container.ExoContainer;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.MockitoJUnitRunner;
+
 import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.container.PortalContainer;
 import org.exoplatform.services.listener.ListenerService;
 import org.exoplatform.task.TestDtoUtils;
 import org.exoplatform.task.TestUtils;
-import org.exoplatform.task.dao.*;
+import org.exoplatform.task.dao.DAOHandler;
+import org.exoplatform.task.dao.ProjectHandler;
+import org.exoplatform.task.dao.ProjectQuery;
+import org.exoplatform.task.dao.StatusHandler;
+import org.exoplatform.task.dao.TaskHandler;
 import org.exoplatform.task.domain.Project;
 import org.exoplatform.task.domain.Status;
 import org.exoplatform.task.domain.Task;
-import org.exoplatform.task.dao.ProjectQuery;
 import org.exoplatform.task.dto.ProjectDto;
 import org.exoplatform.task.exception.EntityNotFoundException;
 import org.exoplatform.task.exception.NotAllowedOperationOnEntityException;
@@ -36,25 +62,12 @@ import org.exoplatform.task.storage.StatusStorage;
 import org.exoplatform.task.storage.TaskStorage;
 import org.exoplatform.task.storage.impl.ProjectStorageImpl;
 import org.exoplatform.task.storage.impl.StatusStorageImpl;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
-import org.mockito.Mock;
-import org.mockito.runners.MockitoJUnitRunner;
-
-import java.util.*;
-
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.*;
 
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class StatusServiceTest {
+
+    MockedStatic<ExoContainerContext> containerContext;
 
     StatusService statusService;
 
@@ -82,13 +95,25 @@ public class StatusServiceTest {
     @Captor
     ArgumentCaptor<Task> taskCaptor;
 
+    PortalContainer                 container;
+
     @Before
     public void setUp() {
         // Make sure the container is started to prevent the ExoTransactional annotation to fail
-        PortalContainer.getInstance();
+      container = PortalContainer.getInstance();
         projectStorage = new ProjectStorageImpl(daoHandler);
         statusStorage = new StatusStorageImpl(daoHandler, projectStorage);
         statusService = new StatusServiceImpl(daoHandler, statusStorage, projectStorage, listenerService);
+
+        containerContext = mockStatic(ExoContainerContext.class);
+        containerContext.when(() -> ExoContainerContext.getService(any())).thenAnswer(invocation -> {
+          Class<?> clazz = invocation.getArgument(0, Class.class);
+          if (clazz.equals(DAOHandler.class)) {
+            return daoHandler;
+          } else {
+            return container.getComponentInstanceOfType(clazz);
+          }
+        });
 
         //Mock DAO handler to return Mocked DAO
         when(daoHandler.getTaskHandler()).thenReturn(taskHandler);
@@ -103,6 +128,8 @@ public class StatusServiceTest {
     @After
     public void tearDown() {
         statusService = null;
+        containerContext.close();
+        containerContext = null;
     }
 
     @Test

--- a/services/src/test/java/org/exoplatform/task/service/StatusServiceTest.java
+++ b/services/src/test/java/org/exoplatform/task/service/StatusServiceTest.java
@@ -101,8 +101,9 @@ public class StatusServiceTest {
     public void setUp() {
         // Make sure the container is started to prevent the ExoTransactional annotation to fail
       container = PortalContainer.getInstance();
-        projectStorage = new ProjectStorageImpl(daoHandler);
-        statusStorage = new StatusStorageImpl(daoHandler, projectStorage);
+      projectStorage = new ProjectStorageImpl(daoHandler);
+      taskStorage = container.getComponentInstanceOfType(TaskStorage.class);
+        statusStorage = new StatusStorageImpl(daoHandler, taskStorage, projectStorage);
         statusService = new StatusServiceImpl(daoHandler, statusStorage, projectStorage, listenerService);
 
         containerContext = mockStatic(ExoContainerContext.class);

--- a/services/src/test/java/org/exoplatform/task/service/TaskServiceTest.java
+++ b/services/src/test/java/org/exoplatform/task/service/TaskServiceTest.java
@@ -52,9 +52,11 @@ import org.exoplatform.task.TestDtoUtils;
 import org.exoplatform.task.TestUtils;
 import org.exoplatform.task.dao.CommentHandler;
 import org.exoplatform.task.dao.DAOHandler;
+import org.exoplatform.task.dao.LabelTaskMappingHandler;
 import org.exoplatform.task.dao.ProjectHandler;
 import org.exoplatform.task.dao.StatusHandler;
 import org.exoplatform.task.dao.TaskHandler;
+import org.exoplatform.task.dao.TaskLogHandler;
 import org.exoplatform.task.domain.Task;
 import org.exoplatform.task.dto.TaskDto;
 import org.exoplatform.task.exception.EntityNotFoundException;
@@ -74,44 +76,50 @@ public class TaskServiceTest {
 
   MockedStatic<ExoContainerContext> containerContext;
 
-  TaskService          taskService;
+  TaskService                       taskService;
 
-  TaskStorage          taskStorage;
+  TaskStorage                       taskStorage;
 
-  StatusStorage        statusStorage;
+  StatusStorage                     statusStorage;
 
-  ListenerService      listenerService;
+  ListenerService                   listenerService;
 
-  TaskSearchConnector  taskSearchConnector;
-
-  @Mock
-  TaskHandler          taskHandler;
+  TaskSearchConnector               taskSearchConnector;
 
   @Mock
-  ProjectHandler       projectHandler;
+  TaskHandler                       taskHandler;
 
   @Mock
-  StatusHandler        statusHandler;
+  ProjectHandler                    projectHandler;
 
   @Mock
-  CommentHandler       commentHandler;
+  LabelTaskMappingHandler           labelTaskMappingHandler;
 
   @Mock
-  StatusService        statusService;
+  StatusHandler                     statusHandler;
 
   @Mock
-  ProjectStorage       projectStorage;
+  CommentHandler                    commentHandler;
 
   @Mock
-  DAOHandler           daoHandler;
+  TaskLogHandler                    taskLogHandler;
 
   @Mock
-  UserService          userService;
+  StatusService                     statusService;
+
+  @Mock
+  ProjectStorage                    projectStorage;
+
+  @Mock
+  DAOHandler                        daoHandler;
+
+  @Mock
+  UserService                       userService;
 
   // ArgumentCaptors are how you can retrieve objects that were passed into a
   // method call
   @Captor
-  ArgumentCaptor<Task> taskCaptor;
+  ArgumentCaptor<Task>              taskCaptor;
 
   PortalContainer                   container;
 
@@ -141,6 +149,9 @@ public class TaskServiceTest {
     when(daoHandler.getTaskHandler()).thenReturn(taskHandler);
     when(daoHandler.getStatusHandler()).thenReturn(statusHandler);
     when(daoHandler.getProjectHandler()).thenReturn(projectHandler);
+    when(daoHandler.getLabelTaskMappingHandler()).thenReturn(labelTaskMappingHandler);
+    when(daoHandler.getCommentHandler()).thenReturn(commentHandler);
+    when(daoHandler.getTaskLogHandler()).thenReturn(taskLogHandler);
 
     // Mock some DAO methods
     when(taskHandler.create(any(Task.class))).thenReturn(TestUtils.getDefaultTask());

--- a/services/src/test/java/org/exoplatform/task/service/TaskServiceTest.java
+++ b/services/src/test/java/org/exoplatform/task/service/TaskServiceTest.java
@@ -18,8 +18,11 @@ package org.exoplatform.task.service;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -29,11 +32,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.exoplatform.task.model.TaskSearchFilter;
-import org.exoplatform.task.storage.ProjectStorage;
-import org.exoplatform.task.storage.StatusStorage;
-import org.exoplatform.task.storage.impl.ProjectStorageImpl;
-import io.meeds.task.search.TaskSearchConnector;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -41,10 +39,10 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.junit.MockitoJUnitRunner;
 
-import org.exoplatform.container.ExoContainer;
 import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.container.PortalContainer;
 import org.exoplatform.services.listener.ListenerService;
@@ -54,17 +52,27 @@ import org.exoplatform.task.TestDtoUtils;
 import org.exoplatform.task.TestUtils;
 import org.exoplatform.task.dao.CommentHandler;
 import org.exoplatform.task.dao.DAOHandler;
+import org.exoplatform.task.dao.ProjectHandler;
+import org.exoplatform.task.dao.StatusHandler;
 import org.exoplatform.task.dao.TaskHandler;
 import org.exoplatform.task.domain.Task;
 import org.exoplatform.task.dto.TaskDto;
 import org.exoplatform.task.exception.EntityNotFoundException;
 import org.exoplatform.task.exception.ParameterEntityException;
+import org.exoplatform.task.model.TaskSearchFilter;
 import org.exoplatform.task.service.impl.TaskServiceImpl;
+import org.exoplatform.task.storage.ProjectStorage;
+import org.exoplatform.task.storage.StatusStorage;
 import org.exoplatform.task.storage.TaskStorage;
+import org.exoplatform.task.storage.impl.ProjectStorageImpl;
 import org.exoplatform.task.storage.impl.TaskStorageImpl;
 
-@RunWith(MockitoJUnitRunner.class)
+import io.meeds.task.search.TaskSearchConnector;
+
+@RunWith(MockitoJUnitRunner.Silent.class)
 public class TaskServiceTest {
+
+  MockedStatic<ExoContainerContext> containerContext;
 
   TaskService          taskService;
 
@@ -77,10 +85,13 @@ public class TaskServiceTest {
   TaskSearchConnector  taskSearchConnector;
 
   @Mock
-  ExoContainer         container;
+  TaskHandler          taskHandler;
 
   @Mock
-  TaskHandler          taskHandler;
+  ProjectHandler       projectHandler;
+
+  @Mock
+  StatusHandler        statusHandler;
 
   @Mock
   CommentHandler       commentHandler;
@@ -102,11 +113,13 @@ public class TaskServiceTest {
   @Captor
   ArgumentCaptor<Task> taskCaptor;
 
+  PortalContainer                   container;
+
   @Before
   public void setUp() throws Exception {
     // Make sure the container is started to prevent the ExoTransactional annotation
     // to fail
-    PortalContainer.getInstance();
+    container = PortalContainer.getInstance();
 
     listenerService = new ListenerService(new ExoContainerContext(container));
     taskSearchConnector = Mockito.mock(TaskSearchConnector.class);
@@ -114,8 +127,21 @@ public class TaskServiceTest {
     taskStorage = new TaskStorageImpl(daoHandler,userService,projectStorage, taskSearchConnector);
     taskService = new TaskServiceImpl(taskStorage, daoHandler, listenerService);
 
+    containerContext = mockStatic(ExoContainerContext.class);
+    containerContext.when(() -> ExoContainerContext.getService(any())).thenAnswer(invocation -> {
+      Class<?> clazz = invocation.getArgument(0, Class.class);
+      if (clazz.equals(DAOHandler.class)) {
+        return daoHandler;
+      } else {
+        return container.getComponentInstanceOfType(clazz);
+      }
+    });
+
     // Mock DAO handler to return Mocked DAO
     when(daoHandler.getTaskHandler()).thenReturn(taskHandler);
+    when(daoHandler.getStatusHandler()).thenReturn(statusHandler);
+    when(daoHandler.getProjectHandler()).thenReturn(projectHandler);
+
     // Mock some DAO methods
     when(taskHandler.create(any(Task.class))).thenReturn(TestUtils.getDefaultTask());
     when(taskHandler.update((any(Task.class)))).thenReturn(TestUtils.getDefaultTask());
@@ -132,6 +158,8 @@ public class TaskServiceTest {
   @After
   public void tearDown() {
     taskService = null;
+    containerContext.close();
+    containerContext = null;
     ConversationState.setCurrent(null);
   }
 
@@ -307,7 +335,7 @@ public class TaskServiceTest {
 
     assertEquals(newAssignee, taskCaptor.getValue().getAssignee());
 
-    assertEquals(task.getId(), taskCaptor.getValue().getId());
+    assertEquals(task.getId(), taskCaptor.getValue().getId().longValue());
 
   }
 
@@ -318,7 +346,7 @@ public class TaskServiceTest {
     taskService.removeTask(TestUtils.EXISTING_TASK_ID);
     verify(taskHandler, times(1)).delete(taskCaptor.capture());
 
-    assertEquals(TestUtils.EXISTING_TASK_ID, taskCaptor.getValue().getId());
+    assertEquals(TestUtils.EXISTING_TASK_ID, taskCaptor.getValue().getId().longValue());
   }
 
   @Test

--- a/services/src/test/java/org/exoplatform/task/service/TaskStorageTest.java
+++ b/services/src/test/java/org/exoplatform/task/service/TaskStorageTest.java
@@ -89,15 +89,7 @@ public class TaskStorageTest extends AbstractTest {
 
   @After
   public void tearDown() {
-    for (Task t : tDAO.findAll()) {
-      t.setStatus(null);
-    }
-    tDAO.updateAll(tDAO.findAll());
-    daoHandler.getLabelTaskMappingHandler().deleteAll();
-    daoHandler.getTaskLogHandler().deleteAll();
-    cDAO.deleteAll();
-    tDAO.deleteAll();
-    labelHandler.deleteAll();
+    deleteAll();
   }
 
   @Test

--- a/services/src/test/java/org/exoplatform/task/storage/CommentStorageTest.java
+++ b/services/src/test/java/org/exoplatform/task/storage/CommentStorageTest.java
@@ -30,6 +30,7 @@ import org.junit.Test;
 import org.exoplatform.commons.utils.ListAccess;
 import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.container.PortalContainer;
+import org.exoplatform.container.component.RequestLifeCycle;
 import org.exoplatform.task.AbstractTest;
 import org.exoplatform.task.dao.DAOHandler;
 import org.exoplatform.task.dao.TaskHandler;
@@ -65,9 +66,7 @@ public class CommentStorageTest extends AbstractTest {
 
   @After
   public void cleanData() {
-    endRequestLifecycle();
-    commentDAO.deleteAll();
-    taskDAO.deleteAll();
+    deleteAll();
   }
   @Test
   public void testMentionedUsers() throws EntityNotFoundException {


### PR DESCRIPTION
This change will upgrade Hibernate to version 6.6 which introduced a bug fix (as explained in https://discourse.hibernate.org/t/instance-save-transient-before/10293/2) which makes some operations buggy when made in the same transaction. This change ensures to split operations to not hit such a problem.

Resolves Meeds-io/meeds#3365