### PR TITLE
fix: Fix Updating JPA Entities with Cloning Entity Strategy - MEED-9358 - Meeds-io/meeds#3365

### DIFF
--- a/services/src/main/java/io/meeds/task/domain/LabelField.java
+++ b/services/src/main/java/io/meeds/task/domain/LabelField.java
@@ -1,30 +1,26 @@
 /**
  * This file is part of the Meeds project (https://meeds.io/).
- * Copyright (C) 2022 Meeds Association
- * contact@meeds.io
+ * 
+ * Copyright (C) 2025 Meeds Association contact@meeds.io
+ * 
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
  * License as published by the Free Software Foundation; either
  * version 3 of the License, or (at your option) any later version.
+ * 
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
+ * 
  * You should have received a copy of the GNU Lesser General Public License
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-package org.exoplatform.task.dao;
+package io.meeds.task.domain;
 
-import java.io.Serializable;
+public enum LabelField {
 
-import org.exoplatform.commons.api.persistence.GenericDAO;
-import org.exoplatform.commons.utils.ListAccess;
-import org.exoplatform.task.domain.LabelTaskMapping;
+  NAME, COLOR, PARENT, HIDDEN
 
-public interface LabelTaskMappingHandler extends GenericDAO<LabelTaskMapping, Serializable> {
-    LabelTaskMapping findLabelTaskMapping(long labelId, long taskId);
-
-    ListAccess<LabelTaskMapping> findLabelMappings(long taskId);
 }
-

--- a/services/src/main/java/org/exoplatform/task/dao/condition/Conditions.java
+++ b/services/src/main/java/org/exoplatform/task/dao/condition/Conditions.java
@@ -36,8 +36,8 @@ public class Conditions {
   public static String TASK_STATUS_NAME = "status.name";
   public static String TASK_DUEDATE = "dueDate";
   public static String TASK_PROJECT = "status.project.id";
-  public static String TASK_LABEL_USERNAME = "lblMapping.label.username";
-  public static String TASK_LABEL_ID = "lblMapping.label.id";
+  public static String TASK_LABEL_USERNAME = "labels.label.username";
+  public static String TASK_LABEL_ID = "labels.label.id";
   public static String TASK_COMPLETED = "completed";
   public static String TASK_START_DATE = "startDate";
   public static String TASK_END_DATE = "endDate";
@@ -51,7 +51,7 @@ public class Conditions {
   public static final String PARENT = "parent";
   public static final String PARENT_ID = "parent.id";
   public static final String USERNAME = "username";  
-  public static final String LABEL_TASK_ID = "lblMapping.task.id";
+  public static final String LABEL_TASK_ID = "tasks.task.id";
 
   public static <T> SingleCondition<T> eq(String fieldName, T value) {
     return new SingleCondition<T>(SingleCondition.EQ, fieldName, value);

--- a/services/src/main/java/org/exoplatform/task/dao/jpa/DAOHandlerJPAImpl.java
+++ b/services/src/main/java/org/exoplatform/task/dao/jpa/DAOHandlerJPAImpl.java
@@ -59,7 +59,7 @@ public class DAOHandlerJPAImpl extends AbstractDAOHandler implements DAOHandler 
     } else if (e instanceof Status) {
       return (E)((Status)e).clone();
     } else if (e instanceof Project) {
-      return (E)((Project)e).clone(false);
+      return (E)((Project)e).clone();
     } else if (e instanceof Comment) {
       return (E)((Comment)e).clone();
     } else if (e instanceof ChangeLog) {

--- a/services/src/main/java/org/exoplatform/task/dao/jpa/LabelTaskMappingDAOImpl.java
+++ b/services/src/main/java/org/exoplatform/task/dao/jpa/LabelTaskMappingDAOImpl.java
@@ -17,35 +17,45 @@
 package org.exoplatform.task.dao.jpa;
 
 import java.io.Serializable;
-import java.util.List;
 
 import org.exoplatform.commons.utils.ListAccess;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.task.dao.LabelTaskMappingHandler;
-import org.exoplatform.task.domain.Label;
 import org.exoplatform.task.domain.LabelTaskMapping;
-import org.exoplatform.task.domain.Task;
 
 import jakarta.persistence.PersistenceException;
-import jakarta.persistence.Query;
 import jakarta.persistence.TypedQuery;
 
 public class LabelTaskMappingDAOImpl extends CommonJPADAO<LabelTaskMapping, Serializable> implements LabelTaskMappingHandler {
 
-    private static final Log log = ExoLogger.getExoLogger(LabelTaskMappingDAOImpl.class);
+  private static final String LABEL_ID = "labelId";
 
-    @Override
-    public LabelTaskMapping findLabelTaskMapping(long labelId, long taskId) {
-        TypedQuery<LabelTaskMapping> query = getEntityManager().createNamedQuery("LabelTaskMapping.findLabelMapping", LabelTaskMapping.class);
-        query.setParameter("labelId", labelId);
-        query.setParameter("taskId", taskId);
-        try {
-            return cloneEntity((LabelTaskMapping)query.getSingleResult());
-        } catch (PersistenceException e) {
-            log.error("Error when fetching label mapping", e);
-            return null;
-        }
+  private static final String TASK_ID  = "taskId";
+
+  private static final Log    log      = ExoLogger.getExoLogger(LabelTaskMappingDAOImpl.class);
+
+  @Override
+  public ListAccess<LabelTaskMapping> findLabelMappings(long taskId) {
+    TypedQuery<LabelTaskMapping> query = getEntityManager().createNamedQuery("LabelTaskMapping.findLabelMappingsOfTask", LabelTaskMapping.class);
+    TypedQuery<Long> count = getEntityManager().createNamedQuery("LabelTaskMapping.countLabelMappingsOfTask", Long.class);
+    query.setParameter(TASK_ID, taskId);
+    count.setParameter(TASK_ID, taskId);
+    return new JPAQueryListAccess<>(LabelTaskMapping.class, count, query);
+  }
+
+  @Override
+  public LabelTaskMapping findLabelTaskMapping(long labelId, long taskId) {
+    TypedQuery<LabelTaskMapping> query = getEntityManager().createNamedQuery("LabelTaskMapping.findLabelMapping",
+                                                                             LabelTaskMapping.class);
+    query.setParameter(LABEL_ID, labelId);
+    query.setParameter(TASK_ID, taskId);
+    try {
+      return cloneEntity(query.getSingleResult());
+    } catch (PersistenceException e) {
+      log.error("Error when fetching label mapping", e);
+      return null;
     }
-}
+  }
 
+}

--- a/services/src/main/java/org/exoplatform/task/domain/ChangeLog.java
+++ b/services/src/main/java/org/exoplatform/task/domain/ChangeLog.java
@@ -26,7 +26,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.NamedQuery;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
-import lombok.EqualsAndHashCode;
+import lombok.Data;
 
 @Entity(name = "TaskChangeLog")
 @Table(name = "TASK_CHANGE_LOGS")
@@ -36,7 +36,7 @@ import lombok.EqualsAndHashCode;
         query = "SELECT count(log) FROM TaskChangeLog log WHERE log.task.id = :taskId")
 @NamedQuery(name = "TaskChangeLog.removeChangeLogByTaskId",
         query = "DELETE FROM TaskChangeLog log WHERE log.task.id = :taskId")
-@EqualsAndHashCode
+@Data
 public class ChangeLog implements Comparable<ChangeLog> {
 
   @Id
@@ -59,61 +59,13 @@ public class ChangeLog implements Comparable<ChangeLog> {
   @Column(name="CREATED_TIME")
   private long createdTime = System.currentTimeMillis();
 
-  public long getId() {
-    return id;
-  }
-
-  public void setId(long id) {
-    this.id = id;
-  }
-
-  public Task getTask() {
-    return task;
-  }
-
-  public void setTask(Task task) {
-    this.task = task;
-  }
-
-  public String getAuthor() {
-    return author;
-  }
-
-  public void setAuthor(String author) {
-    this.author = author;
-  }
-
-  public String getActionName() {
-    return actionName;
-  }
-
-  public void setActionName(String change) {
-    this.actionName = change;
-  }
-
-  public String getTarget() {
-    return target;
-  }
-
-  public void setTarget(String target) {
-    this.target = target;
-  }
-
-  public long getCreatedTime() {
-    return createdTime;
-  }
-
-  public void setCreatedTime(long createdTime) {
-    this.createdTime = createdTime;
-  }
-
   @Override
   public int compareTo(ChangeLog o) {
     return (int)(getCreatedTime() - o.getCreatedTime());
   }
 
   @Override
-  public ChangeLog clone() {
+  public ChangeLog clone() { // NOSONAR
     ChangeLog log = new ChangeLog();
     log.setId(getId());
     log.setTask(getTask().clone());

--- a/services/src/main/java/org/exoplatform/task/domain/Comment.java
+++ b/services/src/main/java/org/exoplatform/task/domain/Comment.java
@@ -21,7 +21,6 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.CollectionTable;
@@ -40,6 +39,7 @@ import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import jakarta.persistence.Temporal;
 import jakarta.persistence.TemporalType;
+import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 /**
@@ -57,7 +57,7 @@ import lombok.EqualsAndHashCode;
     query = "DELETE FROM TaskComment c WHERE c.task.id = :taskId")
 @NamedQuery(name = "Comment.findMentionedUsersOfTask",
     query = "SELECT m FROM TaskComment c INNER JOIN c.mentionedUsers m WHERE c.task.id = :taskId")
-@EqualsAndHashCode
+@Data
 public class Comment {
 
   @Id
@@ -73,7 +73,7 @@ public class Comment {
   private String               author;
 
   @Column(name = "CMT")
-  private String               comment;
+  private String               comment; // NOSONAR
 
   @Temporal(TemporalType.TIMESTAMP)
   @Column(name = "CREATED_TIME")
@@ -99,69 +99,9 @@ public class Comment {
   @EqualsAndHashCode.Exclude
   private Set<String>          mentionedUsers = new HashSet<>();
 
-  public Long getId() {
-    return id;
-  }
-
-  public void setId(Long id) {
-    this.id = id;
-  }
-
-  public String getAuthor() {
-    return author;
-  }
-
-  public void setAuthor(String author) {
-    this.author = author;
-  }
-
-  public String getComment() {
-    return comment;
-  }
-
-  public void setComment(String comment) {
-    this.comment = comment;
-  }
-
-  public void setMentionedUsers(Set<String> mentionedUsers) {
-    this.mentionedUsers = mentionedUsers;
-  }
-
-  public Set<String> getMentionedUsers() {
-    return mentionedUsers.stream().collect(Collectors.toSet());
-  }
-
-  public Date getCreatedTime() {
-    return createdTime;
-  }
-
-  public void setCreatedTime(Date createdTime) {
-    this.createdTime = createdTime;
-  }
-
-  public Task getTask() {
-    return task;
-  }
-
-  public void setTask(Task task) {
-    this.task = task;
-  }
-
-  public Comment getParentComment() {
-    return parentComment;
-  }
-
   public void setParentComment(Comment parentComment) {
     this.parentComment = parentComment;
     this.parentComment.addSubComment(this);
-  }
-
-  public List<Comment> getSubComments() {
-    return subComments;
-  }
-
-  public void setSubComments(List<Comment> subComments) {
-    this.subComments = subComments;
   }
 
   public void addSubComment(Comment subComment) {

--- a/services/src/main/java/org/exoplatform/task/domain/Label.java
+++ b/services/src/main/java/org/exoplatform/task/domain/Label.java
@@ -34,19 +34,20 @@ import jakarta.persistence.NamedQuery;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
+import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 @Entity(name = "TaskLabel")
 @Table(name = "TASK_LABELS")
 @NamedQuery(name = "Label.findLabelsByTask",
-  query = "SELECT lbl FROM TaskLabel lbl inner join lbl.lblMapping m WHERE lbl.project.id = :projectId AND m.task.id = :taskid ORDER BY lbl.id")
+  query = "SELECT lbl FROM TaskLabel lbl inner join lbl.tasks m WHERE lbl.project.id = :projectId AND m.task.id = :taskid ORDER BY lbl.id")
 @NamedQuery(name = "Label.findLabelsByTaskCount",
-  query = "SELECT count(*) FROM TaskLabel lbl inner join lbl.lblMapping m WHERE lbl.project.id = :projectId AND m.task.id = :taskid")
+  query = "SELECT count(*) FROM TaskLabel lbl inner join lbl.tasks m WHERE lbl.project.id = :projectId AND m.task.id = :taskid")
 @NamedQuery(name = "Label.findLabelsByProject",
   query = "SELECT lbl FROM TaskLabel lbl WHERE lbl.project.id = :projectId ORDER BY lbl.id")
 @NamedQuery(name = "Label.findLabelsByProjectCount",
   query = "SELECT count(*) FROM TaskLabel lbl WHERE lbl.project.id = :projectId ORDER BY lbl.id")
-@EqualsAndHashCode
+@Data
 public class Label implements Serializable {
 
   private static final long serialVersionUID = 806731692361018042L;
@@ -78,7 +79,7 @@ public class Label implements Serializable {
   //Still use for named query
   @OneToMany(mappedBy = "label", fetch=FetchType.LAZY)
   @EqualsAndHashCode.Exclude
-  private Set<LabelTaskMapping> lblMapping = new HashSet<>();
+  private Set<LabelTaskMapping> tasks = new HashSet<>();
 
   @ManyToOne
   @JoinColumn(name = "PROJECT_ID")
@@ -94,72 +95,4 @@ public class Label implements Serializable {
     this.project = project;
   }
 
-  public long getId() {
-    return id;
-  }
-
-  public void setId(long id) {
-    this.id = id;
-  }
-
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  public String getColor() {
-    return color;
-  }
-
-  public void setColor(String color) {
-    this.color = color;
-  }
-
-  public Label getParent() {
-    return parent;
-  }
-
-  public void setParent(Label parent) {
-    this.parent = parent;
-  }
-
-  public List<Label> getChildren() {
-    return children;
-  }
-
-  public void setChildren(List<Label> children) {
-    this.children = children;
-  }
-
-  public String getUsername() {
-    return username;
-  }
-
-  public void setUsername(String username) {
-    this.username = username;
-  }
-
-  public Project getProject() {
-    return project;
-  }
-
-  public void setProject(Project project) {
-    this.project = project;
-  }
-
-  public boolean isHidden() {
-    return hidden;
-  }
-
-  public void setHidden(boolean hidden) {
-    this.hidden = hidden;
-  }
-
-  public enum FIELDS {
-    NAME, COLOR, PARENT, HIDDEN
-  }
-  
 }

--- a/services/src/main/java/org/exoplatform/task/domain/LabelTaskMapping.java
+++ b/services/src/main/java/org/exoplatform/task/domain/LabelTaskMapping.java
@@ -22,18 +22,22 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.NamedQueries;
 import jakarta.persistence.NamedQuery;
 import jakarta.persistence.Table;
+import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 @Entity(name = "TaskLabelTaskMapping")
 @Table(name = "TASK_LABEL_TASK")
+@NamedQuery(name = "LabelTaskMapping.countLabelMappingsOfTask",
+  query = "SELECT count(m) FROM TaskLabelTaskMapping m WHERE m.task.id = :taskId")
+@NamedQuery(name = "LabelTaskMapping.findLabelMappingsOfTask",
+  query = "SELECT m FROM TaskLabelTaskMapping m WHERE m.task.id = :taskId")
 @NamedQuery(name = "LabelTaskMapping.removeLabelTaskMapping",
     query = "DELETE FROM TaskLabelTaskMapping m WHERE m.label.id = :labelId")
 @NamedQuery(name = "LabelTaskMapping.findLabelMapping",
      query = "SELECT m FROM TaskLabelTaskMapping m  WHERE m.label.id = :labelId and  m.task.id = :taskId")
-@EqualsAndHashCode
+@Data
 public class LabelTaskMapping implements Serializable {
 
   private static final long serialVersionUID = -8180443225233907972L;
@@ -49,29 +53,12 @@ public class LabelTaskMapping implements Serializable {
   @EqualsAndHashCode.Exclude
   private Task              task;
 
-  public LabelTaskMapping() {    
+  public LabelTaskMapping() {
   }
-  
+
   public LabelTaskMapping(Label label, Task task) {
     super();
     this.label = label;
     this.task = task;
   }
-
-  public Label getLabel() {
-    return label;
-  }
-  
-  public void setLabel(Label label) {
-    this.label = label;
-  }
-  
-  public Task getTask() {
-    return task;
-  }
-  
-  public void setTask(Task task) {
-    this.task = task;
-  }
-  
 }

--- a/services/src/main/java/org/exoplatform/task/domain/Project.java
+++ b/services/src/main/java/org/exoplatform/task/domain/Project.java
@@ -25,7 +25,6 @@ import java.util.Set;
 
 import org.exoplatform.services.security.Identity;
 import org.exoplatform.services.security.MembershipEntry;
-import org.exoplatform.task.util.ProjectUtil;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.CollectionTable;
@@ -45,6 +44,7 @@ import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import jakarta.persistence.Temporal;
 import jakarta.persistence.TemporalType;
+import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 /**
@@ -102,7 +102,7 @@ import lombok.EqualsAndHashCode;
                 + " LEFT JOIN p.participator participator "
                 + " WHERE (manager IN (:memberships) OR participator IN (:memberships)) AND LOWER(p.name) LIKE LOWER(CONCAT('%', :name, '%'))"
 )
-@EqualsAndHashCode
+@Data
 public class Project implements Serializable {
 
   private static final long  serialVersionUID = -5595949787344061794L;
@@ -121,7 +121,7 @@ public class Project implements Serializable {
 
   private String             color;
 
-  @OneToMany(mappedBy = "project", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true)
+  @OneToMany(mappedBy = "project", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
   @EqualsAndHashCode.Exclude
   private Set<Status>        status;
 
@@ -170,108 +170,8 @@ public class Project implements Serializable {
     this.participator = participator;
   }
 
-  public long getId() {
-    return id;
-  }
-
-  public void setId(long id) {
-    this.id = id;
-  }
-
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  //TODO: get list status of project via StatusService
-  @Deprecated
-  public Set<Status> getStatus() {
-    return status;
-  }
-
-  @Deprecated
-  public void setStatus(Set<Status> status) {
-    this.status = status;
-  }
-
-  @Deprecated
-  public Set<String> getParticipator() {
-    if (participator == null) {
-      participator = ProjectUtil.getParticipator(getId());
-    }
-    return participator;
-  }
-
-  public void setParticipator(Set<String> participator) {
-    this.participator = participator;
-  }
-
-  @Deprecated
-  public Set<String> getManager() {
-    if (manager == null) {
-      manager = ProjectUtil.getManager(getId());
-    }
-    return manager;
-  }
-
-  public void setManager(Set<String> manager) {
-    this.manager = manager;
-  }
-
-  public String getDescription() {
-    return description;
-  }
-
-  public void setDescription(String description) {
-    this.description = description;
-  }
-
-  public Date getDueDate() {
-    return dueDate;
-  }
-
-  public void setDueDate(Date dueDate) {
-    this.dueDate = dueDate;
-  }
-
-  public String getColor() {
-    return color;
-  }
-
-  public void setColor(String color) {
-    this.color = color;
-  }
-
-  public Project getParent() {
-    return parent;
-  }
-
-  public void setParent(Project parent) {
-    this.parent = parent;
-  }
-
-  public Long getLastModifiedDate() {
-    return lastModifiedDate;
-  }
-
-  public void setLastModifiedDate(Long lastModifiedDate) {
-    this.lastModifiedDate = lastModifiedDate;
-  }
-
-  @Deprecated
-  public List<Project> getChildren() {
-    return children;
-  }
-
-  @Deprecated
-  public void setChildren(List<Project> children) {
-    this.children = children;
-  }
-
-  public Project clone(boolean cloneTask) {
+  @Override
+  public Project clone() { // NOSONAR
     Project project = new Project(this.getName(),
                                   this.getDescription(),
                                   new HashSet<>(),
@@ -281,7 +181,7 @@ public class Project implements Serializable {
     project.setColor(this.getColor());
     project.setDueDate(this.getDueDate());
     if (this.getParent() != null) {
-      project.setParent(getParent().clone(false));
+      project.setParent(getParent().clone());
     }
     project.status = new HashSet<>();
     project.children = new LinkedList<>();
@@ -289,7 +189,7 @@ public class Project implements Serializable {
   }
 
   public boolean canView(Identity user) {
-    Set<String> permissions = new HashSet<String>(getParticipator());
+    Set<String> permissions = new HashSet<>(getParticipator());
     permissions.addAll(getManager());
 
     return hasPermission(user, permissions);
@@ -319,10 +219,6 @@ public class Project implements Serializable {
     }
 
     return false;
-  }
-
-  public Set<UserSetting> getHiddenOn() {
-    return hiddenOn;
   }
 
 }

--- a/services/src/main/java/org/exoplatform/task/domain/Status.java
+++ b/services/src/main/java/org/exoplatform/task/domain/Status.java
@@ -32,6 +32,7 @@ import jakarta.persistence.NamedQuery;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
+import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 /**
@@ -55,7 +56,7 @@ import lombok.EqualsAndHashCode;
             query = "SELECT s FROM TaskStatus s WHERE s.name = :name AND s.project.id = :projectID")
 @NamedQuery(name = "Status.findStatusByProject",
             query = "SELECT s FROM TaskStatus s WHERE s.project.id = :projectId ORDER BY s.rank ASC")
-@EqualsAndHashCode
+@Data
 public class Status implements Comparable<Status>, Serializable {
 
   private static final long serialVersionUID = -3079376553215147896L;
@@ -73,7 +74,7 @@ public class Status implements Comparable<Status>, Serializable {
 
   // This field only used for cascade remove
   @EqualsAndHashCode.Exclude
-  @OneToMany(mappedBy = "status", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true)
+  @OneToMany(mappedBy = "status", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
   private List<Task>        tasks;
 
   @ManyToOne
@@ -84,11 +85,11 @@ public class Status implements Comparable<Status>, Serializable {
   public Status() {
   }
 
-  //TO REMOVE after removing the TaskServiceMemImpl
   public Status(long id, String name) {
     this.id = id;
     this.name = name;
   }
+
   public Status(long id, String name, Integer rank, Project project) {
     this.id = id;
     this.name = name;
@@ -102,41 +103,9 @@ public class Status implements Comparable<Status>, Serializable {
     this.project = project;
   }
 
-  public long getId() {
-    return id;
-  }
-
-  public void setId(long id) {
-    this.id = id;
-  }
-
-  public String getName() {
-    return name;
-  }
-
-  public void setName(String name) {
-    this.name = name;
-  }
-
-  public Integer getRank() {
-    return rank;
-  }
-
-  public void setRank(Integer rank) {
-    this.rank = rank;
-  }
-
-  public Project getProject() {
-    return project;
-  }
-
-  public void setProject(Project project) {
-    this.project = project;
-  }
-
   @Override
   public Status clone() { // NOSONAR
-    return new Status(getId(), getName(), getRank(), getProject().clone(false));
+    return new Status(getId(), getName(), getRank(), getProject().clone());
   }
 
   @Override

--- a/services/src/main/java/org/exoplatform/task/domain/Task.java
+++ b/services/src/main/java/org/exoplatform/task/domain/Task.java
@@ -41,6 +41,7 @@ import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import jakarta.persistence.Temporal;
 import jakarta.persistence.TemporalType;
+import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 /**
@@ -157,7 +158,7 @@ import lombok.EqualsAndHashCode;
 
 @NamedQuery(name = "Task.getAllIds",
         query = "SELECT t.id FROM TaskTask t ORDER BY id ASC LIMIT :limit OFFSET :offset")
-@EqualsAndHashCode
+@Data
 public class Task implements Serializable {
 
   private static final long     serialVersionUID = 1945617316471028822L;
@@ -221,18 +222,18 @@ public class Task implements Serializable {
   private Date        dueDate;
 
   //This field is only used for remove cascade
-  @OneToMany(mappedBy = "task", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true)
+  @OneToMany(mappedBy = "task", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
   @EqualsAndHashCode.Exclude
   private List<Comment> comments; // NOSONAR
 
   //This field is only used for remove cascade
-  @OneToMany(mappedBy = "task", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true)
+  @OneToMany(mappedBy = "task", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
   @EqualsAndHashCode.Exclude
   private List<ChangeLog> logs; // NOSONAR
 
-  @OneToMany(mappedBy = "task", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true)
+  @OneToMany(mappedBy = "task", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
   @EqualsAndHashCode.Exclude
-  private Set<LabelTaskMapping> lblMapping;
+  private List<LabelTaskMapping> labels;
 
   @Column(name = "ACTIVITY_ID")
   private String activityId;
@@ -265,142 +266,6 @@ public class Task implements Serializable {
     this.endDate = endDate;
     this.dueDate = dueDate;
     this.status = status;
-  }
-
-  public Long getId() {
-    return id;
-  }
-
-  public void setId(Long id) {
-    this.id = id;
-  }
-
-  public String getTitle() {
-    return title;
-  }
-
-  public void setTitle(String title) {
-    this.title = title;
-  }
-
-  public String getDescription() {
-    return description;
-  }
-
-  public void setDescription(String description) {
-    this.description = description;
-  }
-
-  public Priority getPriority() {
-    return priority;
-  }
-
-  public void setPriority(Priority priority) {
-    this.priority = priority;
-  }
-
-  public String getContext() {
-    return context;
-  }
-
-  public void setContext(String context) {
-    this.context = context;
-  }
-
-  public String getAssignee() {
-    return assignee;
-  }
-
-  public void setAssignee(String assignee) {
-    this.assignee = assignee;
-  }
-
-  public Status getStatus() {
-    return status;
-  }
-
-  public void setStatus(Status status) {
-    this.status = status;
-  }
-
-  public int getRank() {
-    return rank;
-  }
-
-  public void setRank(int rank) {
-    this.rank = rank;
-  }
-
-  public boolean isCompleted() {
-    return completed;
-  }
-
-  public void setCompleted(boolean completed) {
-    this.completed = completed;
-  }
-
-  public String getCreatedBy() {
-    return createdBy;
-  }
-
-  public void setCreatedBy(String createdBy) {
-    this.createdBy = createdBy;
-  }
-
-  public Date getCreatedTime() {
-    return createdTime;
-  }
-
-  public void setCreatedTime(Date createdTime) {
-    this.createdTime = createdTime;
-  }
-
-  public Date getEndDate() {
-    return endDate;
-  }
-
-  public void setEndDate(Date endDate) {
-    this.endDate = endDate;
-  }
-
-  public Date getStartDate() {
-    return startDate;
-  }
-
-  public void setStartDate(Date startDate) {
-    this.startDate = startDate;
-  }
-
-  public Date getDueDate() {
-    return dueDate;
-  }
-
-  public void setDueDate(Date dueDate) {
-    this.dueDate = dueDate;
-  }
-
-  public Set<String> getCoworker() {
-    return coworker;
-  }
-
-  public void setCoworker(Set<String> coworker) {
-    this.coworker = coworker;
-  }
-
-  public Set<String> getWatcher() {
-    return watcher;
-  }
-
-  public void setWatcher(Set<String> watcher) {
-    this.watcher = watcher;
-  }
-
-  public String getActivityId() {
-    return activityId;
-  }
-
-  public void setActivityId(String activityId) {
-    this.activityId = activityId;
   }
 
   @Override

--- a/services/src/main/java/org/exoplatform/task/domain/UserSetting.java
+++ b/services/src/main/java/org/exoplatform/task/domain/UserSetting.java
@@ -18,6 +18,7 @@ package org.exoplatform.task.domain;
 
 import java.io.Serializable;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import jakarta.persistence.Column;
@@ -27,6 +28,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.JoinTable;
 import jakarta.persistence.ManyToMany;
 import jakarta.persistence.Table;
+import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 /**
@@ -34,7 +36,7 @@ import lombok.EqualsAndHashCode;
  */
 @Entity(name = "TaskUserSetting")
 @Table(name = "TASK_USER_SETTINGS")
-@EqualsAndHashCode
+@Data
 public class UserSetting implements Serializable {
 
   private static final long serialVersionUID  = 731610709234552969L;
@@ -68,38 +70,11 @@ public class UserSetting implements Serializable {
     this.username = username;
   }
 
-  public String getUsername() {
-    return username;
-  }
-
-  public boolean isShowHiddenProject() {
-    return showHiddenProject;
-  }
-
-  public void setShowHiddenProject(boolean showHiddenProject) {
-    this.showHiddenProject = showHiddenProject;
-  }
-
-  public boolean isShowHiddenLabel() {
-    return showHiddenLabel;
-  }
-
-  public void setShowHiddenLabel(boolean showHiddenLabel) {
-    this.showHiddenLabel = showHiddenLabel;
-  }
-
-  public Set<Project> getHiddenProjects() {
-    return hiddenProjects;
-  }
-
-  public void setHiddenProjects(Set<Project> hiddenProjects) {
-    this.hiddenProjects = hiddenProjects;
-  }
-
   @Override
   public UserSetting clone() { // NOSONAR
     UserSetting setting = new UserSetting(getUsername());
     setting.setShowHiddenProject(isShowHiddenProject());
     return setting;
   }
+
 }

--- a/services/src/main/java/org/exoplatform/task/dto/UserSettingDto.java
+++ b/services/src/main/java/org/exoplatform/task/dto/UserSettingDto.java
@@ -22,7 +22,6 @@ import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Set;
 
-
 @Data
 public class UserSettingDto implements Serializable {
     private String username;
@@ -36,10 +35,10 @@ public class UserSettingDto implements Serializable {
     public UserSettingDto clone() {
         UserSettingDto setting = new UserSettingDto();
         setting.setShowHiddenProject(isShowHiddenProject());
-        Set<Project> hiddenProjects = new HashSet<Project>();
+        Set<Project> hiddenProjects = new HashSet<>();
         if (getHiddenProjects() != null) {
             for (Project p : getHiddenProjects()) {
-                hiddenProjects.add(p.clone(false));
+                hiddenProjects.add(p.clone());
             }
         }
         setting.setHiddenProjects(hiddenProjects);

--- a/services/src/main/java/org/exoplatform/task/rest/ProjectRestService.java
+++ b/services/src/main/java/org/exoplatform/task/rest/ProjectRestService.java
@@ -644,7 +644,7 @@ public class ProjectRestService implements ResourceContainer {
   @Consumes(MediaType.APPLICATION_JSON)
   @RolesAllowed("users")
   @Operation(summary = "Delete Project", method = "DELETE", description = "This deletes the Project")
-  @ApiResponses(value = { @ApiResponse(responseCode = "200", description = "Project deleted"),
+  @ApiResponses(value = { @ApiResponse(responseCode = "204", description = "Project deleted"),
       @ApiResponse(responseCode = "400", description = "Invalid query input"),
       @ApiResponse(responseCode = "401", description = "User not authorized to delete the Project"),
       @ApiResponse(responseCode = "500", description = "Internal server error") })
@@ -667,7 +667,7 @@ public class ProjectRestService implements ResourceContainer {
       }
 
       projectService.removeProject(projectId, deleteChild);
-      return Response.ok(Response.Status.OK).build();
+      return Response.noContent().build();
     } catch (Exception e) {
       LOG.error("Can't deleteProject {}", projectId, e);
       return Response.serverError().entity(e.getMessage()).build();

--- a/services/src/main/java/org/exoplatform/task/service/LabelService.java
+++ b/services/src/main/java/org/exoplatform/task/service/LabelService.java
@@ -20,10 +20,11 @@ import java.util.List;
 
 import org.exoplatform.commons.api.persistence.ExoTransactional;
 import org.exoplatform.services.security.Identity;
-import org.exoplatform.task.domain.Label;
 import org.exoplatform.task.dto.LabelDto;
 import org.exoplatform.task.dto.TaskDto;
 import org.exoplatform.task.exception.EntityNotFoundException;
+
+import io.meeds.task.domain.LabelField;
 
 public interface LabelService {
   List<LabelDto> findLabelsByUser(String username, int offset, int limit);
@@ -37,7 +38,7 @@ public interface LabelService {
   LabelDto createLabel(LabelDto label);
 
   @ExoTransactional
-  LabelDto updateLabel(LabelDto label, List<Label.FIELDS> fields) throws EntityNotFoundException;
+  LabelDto updateLabel(LabelDto label, List<LabelField> fields) throws EntityNotFoundException;
 
   LabelDto updateLabel(LabelDto label) throws EntityNotFoundException;
 

--- a/services/src/main/java/org/exoplatform/task/service/impl/LabelServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/task/service/impl/LabelServiceImpl.java
@@ -16,6 +16,10 @@
  */
 package org.exoplatform.task.service.impl;
 
+import java.util.List;
+
+import javax.inject.Inject;
+
 import org.exoplatform.commons.api.persistence.ExoTransactional;
 import org.exoplatform.services.listener.ListenerService;
 import org.exoplatform.services.log.ExoLogger;
@@ -23,7 +27,6 @@ import org.exoplatform.services.log.Log;
 import org.exoplatform.services.security.ConversationState;
 import org.exoplatform.services.security.Identity;
 import org.exoplatform.task.dao.DAOHandler;
-import org.exoplatform.task.domain.Label;
 import org.exoplatform.task.domain.LabelTaskMapping;
 import org.exoplatform.task.dto.LabelDto;
 import org.exoplatform.task.dto.TaskDto;
@@ -33,8 +36,7 @@ import org.exoplatform.task.storage.LabelStorage;
 import org.exoplatform.task.storage.ProjectStorage;
 import org.exoplatform.task.util.StorageUtil;
 
-import javax.inject.Inject;
-import java.util.List;
+import io.meeds.task.domain.LabelField;
 
 public class LabelServiceImpl implements LabelService {
 
@@ -91,14 +93,14 @@ public class LabelServiceImpl implements LabelService {
 
     @Override
     @ExoTransactional
-    public LabelDto updateLabel(LabelDto label, List<Label.FIELDS> fields) throws EntityNotFoundException {
+    public LabelDto updateLabel(LabelDto label, List<LabelField> fields) throws EntityNotFoundException {
         LabelDto lb = getLabel(label.getId());
         if (lb == null) {
             throw new EntityNotFoundException(label.getId(), LabelDto.class);
         }
 
         //Todo: validate input and throw exception if need
-        for (Label.FIELDS field : fields) {
+        for (LabelField field : fields) {
             switch (field) {
                 case NAME:
                     lb.setName(label.getName());

--- a/services/src/main/java/org/exoplatform/task/service/impl/StatusServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/task/service/impl/StatusServiceImpl.java
@@ -139,7 +139,7 @@ public class StatusServiceImpl implements StatusService {
     @Override
     @ExoTransactional
     public void removeStatus(long statusID) throws Exception {
-        statusStorage.removeStatus(statusID);
+        statusStorage.removeStatus(statusID, false);
     }
 
     @Override

--- a/services/src/main/java/org/exoplatform/task/storage/LabelStorage.java
+++ b/services/src/main/java/org/exoplatform/task/storage/LabelStorage.java
@@ -19,10 +19,11 @@ package org.exoplatform.task.storage;
 import java.util.List;
 
 import org.exoplatform.services.security.Identity;
-import org.exoplatform.task.domain.Label;
 import org.exoplatform.task.dto.LabelDto;
 import org.exoplatform.task.dto.TaskDto;
 import org.exoplatform.task.exception.EntityNotFoundException;
+
+import io.meeds.task.domain.LabelField;
 
 public interface LabelStorage {
 
@@ -36,7 +37,7 @@ public interface LabelStorage {
 
   LabelDto createLabel(LabelDto label);
 
-  LabelDto updateLabel(LabelDto label, List<Label.FIELDS> fields) throws EntityNotFoundException;
+  LabelDto updateLabel(LabelDto label, List<LabelField> fields) throws EntityNotFoundException;
 
   void removeLabel(long labelId);
 

--- a/services/src/main/java/org/exoplatform/task/storage/ProjectStorage.java
+++ b/services/src/main/java/org/exoplatform/task/storage/ProjectStorage.java
@@ -75,18 +75,6 @@ public interface ProjectStorage {
     void removeProject(long projectId, boolean deleteChild) throws EntityNotFoundException;
 
     /**
-     * Clone a project with given <code>projectId</code>. If <code>cloneTask</code> is true,
-     * it will also clone all non-completed tasks from the project.
-     *
-     * @param projectId The id of a project which it copies from.
-     * @param cloneTask If false, it will clone only project metadata.
-     *                  Otherwise, it also clones all non-completed tasks from the project.
-     * @return The cloned project.
-     * @throws EntityNotFoundException when user is not authorized to clone project.
-     */
-    ProjectDto cloneProject(long projectId, boolean cloneTask) throws EntityNotFoundException;
-
-    /**
      * Return a list of children of a parent project with given <code>parentId</code>.
      *
      * @param parentId The parent id of a project.

--- a/services/src/main/java/org/exoplatform/task/storage/StatusStorage.java
+++ b/services/src/main/java/org/exoplatform/task/storage/StatusStorage.java
@@ -55,7 +55,7 @@ public interface StatusStorage {
 
   StatusDto createStatus(ProjectDto project, String status, int rank) throws NotAllowedOperationOnEntityException;
 
-  void removeStatus(long statusId) throws Exception;
+  void removeStatus(long statusId, boolean removeAll) throws Exception;
 
   StatusDto updateStatus(long statusId, String statusName) throws EntityNotFoundException, NotAllowedOperationOnEntityException;
 

--- a/services/src/main/java/org/exoplatform/task/storage/impl/LabelStorageImpl.java
+++ b/services/src/main/java/org/exoplatform/task/storage/impl/LabelStorageImpl.java
@@ -29,13 +29,14 @@ import org.exoplatform.services.log.Log;
 import org.exoplatform.services.security.Identity;
 import org.exoplatform.task.dao.DAOHandler;
 import org.exoplatform.task.domain.Label;
-import org.exoplatform.task.domain.Task;
 import org.exoplatform.task.dto.LabelDto;
 import org.exoplatform.task.dto.TaskDto;
 import org.exoplatform.task.exception.EntityNotFoundException;
 import org.exoplatform.task.storage.LabelStorage;
 import org.exoplatform.task.storage.ProjectStorage;
 import org.exoplatform.task.util.StorageUtil;
+
+import io.meeds.task.domain.LabelField;
 
 public class LabelStorageImpl implements LabelStorage {
 
@@ -96,7 +97,7 @@ public class LabelStorageImpl implements LabelStorage {
   }
 
   @Override
-  public LabelDto updateLabel(LabelDto label, List<Label.FIELDS> fields) throws EntityNotFoundException {
+  public LabelDto updateLabel(LabelDto label, List<LabelField> fields) throws EntityNotFoundException {
     return null;
   }
 

--- a/services/src/main/java/org/exoplatform/task/storage/impl/ProjectStorageImpl.java
+++ b/services/src/main/java/org/exoplatform/task/storage/impl/ProjectStorageImpl.java
@@ -16,28 +16,32 @@
  */
 package org.exoplatform.task.storage.impl;
 
-import org.exoplatform.services.log.ExoLogger;
-import org.exoplatform.services.log.Log;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import org.apache.commons.collections4.CollectionUtils;
+
+import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.task.dao.DAOHandler;
 import org.exoplatform.task.dao.OrderBy;
 import org.exoplatform.task.dao.ProjectQuery;
 import org.exoplatform.task.domain.Project;
+import org.exoplatform.task.domain.Status;
 import org.exoplatform.task.dto.ProjectDto;
 import org.exoplatform.task.exception.EntityNotFoundException;
 import org.exoplatform.task.storage.ProjectStorage;
+import org.exoplatform.task.storage.StatusStorage;
 import org.exoplatform.task.util.StorageUtil;
 
-import javax.inject.Inject;
-import java.util.*;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
+import lombok.SneakyThrows;
 
 public class ProjectStorageImpl implements ProjectStorage {
-
-    private static final Log LOG = ExoLogger.getExoLogger(ProjectStorageImpl.class);
-
-    private static final Pattern pattern = Pattern.compile("@([^\\s]+)|@([^\\s]+)$");
-
 
     @Inject
     private final DAOHandler daoHandler;
@@ -58,7 +62,7 @@ public class ProjectStorageImpl implements ProjectStorage {
         ProjectQuery query = new ProjectQuery();
         query.setId(projectId);
         List<String> manager = daoHandler.getProjectHandler().selectProjectField(query, "manager");
-        return new HashSet<String>(manager);
+        return new HashSet<>(manager);
     }
 
     @Override
@@ -66,7 +70,7 @@ public class ProjectStorageImpl implements ProjectStorage {
         ProjectQuery query = new ProjectQuery();
         query.setId(projectId);
         List<String> manager = daoHandler.getProjectHandler().selectProjectField(query, "participator");
-        return new HashSet<String>(manager);
+        return new HashSet<>(manager);
     }
 
     @Override
@@ -93,12 +97,11 @@ public class ProjectStorageImpl implements ProjectStorage {
     public void removeProject(long projectId, boolean deleteChild) throws EntityNotFoundException {
         ProjectDto project = getProject(projectId);
         if (project == null) throw new EntityNotFoundException(projectId, Project.class);
+        List<Status> statuses = daoHandler.getStatusHandler().getStatuses(projectId);
+        if (CollectionUtils.isNotEmpty(statuses)) {
+          statuses.forEach(this::removeStatus);
+        }
         daoHandler.getProjectHandler().removeProject(projectId, deleteChild);
-    }
-
-    @Override
-    public ProjectDto cloneProject(long projectId, boolean cloneTask) throws EntityNotFoundException {
-        return null;
     }
 
     @Override
@@ -138,7 +141,7 @@ public class ProjectStorageImpl implements ProjectStorage {
         try {
             return Arrays.asList(daoHandler.getProjectHandler().findAllByMembershipsAndKeyword(memberships, keyword, order).load(offset, limit)).stream().map((Project project) -> StorageUtil.projectToDto(project,this)).collect(Collectors.toList());
         } catch (Exception e) {
-            return new ArrayList<ProjectDto>();
+            return new ArrayList<>();
         }
     }
 
@@ -147,7 +150,7 @@ public class ProjectStorageImpl implements ProjectStorage {
         try {
             return daoHandler.getProjectHandler().findCollaboratedProjects(userName,keyword,offset, limit).stream().map((Project project) -> StorageUtil.projectToDto(project,this)).collect(Collectors.toList());
         } catch (Exception e) {
-            return new ArrayList<ProjectDto>();
+            return new ArrayList<>();
         }
     }
 
@@ -156,7 +159,7 @@ public class ProjectStorageImpl implements ProjectStorage {
         try {
             return daoHandler.getProjectHandler().findNotEmptyProjects(memberships,keyword,offset, limit).stream().map((Project project) -> StorageUtil.projectToDto(project,this)).collect(Collectors.toList());
         } catch (Exception e) {
-            return new ArrayList<ProjectDto>();
+            return new ArrayList<>();
         }
     }
 
@@ -186,6 +189,12 @@ public class ProjectStorageImpl implements ProjectStorage {
             return 0;
         }
 
+    }
+
+    @SneakyThrows
+    private void removeStatus(Status status) {
+      StatusStorage statusStorage = ExoContainerContext.getService(StatusStorage.class);
+      statusStorage.removeStatus(status.getId(), true);
     }
 
 }

--- a/services/src/main/java/org/exoplatform/task/storage/impl/StatusStorageImpl.java
+++ b/services/src/main/java/org/exoplatform/task/storage/impl/StatusStorageImpl.java
@@ -16,12 +16,15 @@
  */
 package org.exoplatform.task.storage.impl;
 
-import java.util.*;
-import java.util.regex.Pattern;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import javax.inject.Inject;
-import jakarta.persistence.NonUniqueResultException;
 
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
@@ -39,11 +42,11 @@ import org.exoplatform.task.storage.StatusStorage;
 import org.exoplatform.task.storage.TaskStorage;
 import org.exoplatform.task.util.StorageUtil;
 
+import jakarta.persistence.NonUniqueResultException;
+
 public class StatusStorageImpl implements StatusStorage {
 
   private static final Log     LOG     = ExoLogger.getExoLogger(StatusStorageImpl.class);
-
-  private static final Pattern pattern = Pattern.compile("@([^\\s]+)|@([^\\s]+)$");
 
   @Inject
   private final DAOHandler     daoHandler;
@@ -51,9 +54,14 @@ public class StatusStorageImpl implements StatusStorage {
   @Inject
   private final ProjectStorage projectStorage;
 
-  public StatusStorageImpl(DAOHandler daoHandler, ProjectStorage projectStorage) {
+  private final TaskStorage    taskStorage;
+
+  public StatusStorageImpl(DAOHandler daoHandler,
+                           TaskStorage taskStorage,
+                           ProjectStorage projectStorage) {
     this.daoHandler = daoHandler;
     this.projectStorage = projectStorage;
+    this.taskStorage = taskStorage;
   }
 
   @Override
@@ -133,26 +141,27 @@ public class StatusStorageImpl implements StatusStorage {
   }
 
   @Override
-  public void removeStatus(long statusId) throws Exception {
-    StatusHandler handler = daoHandler.getStatusHandler();
-    Status st = handler.find(statusId);
+  public void removeStatus(long statusId, boolean removeAll) throws Exception {
+    Status st = daoHandler.getStatusHandler().find(statusId);
     if (st == null) {
       throw new EntityNotFoundException(statusId, Status.class);
     }
 
-    Project project = st.getProject();
-    Status altStatus = findAltStatus(st, project);
-    if (altStatus == null) {
-      throw new NotAllowedOperationOnEntityException(statusId, Status.class, "Delete last status");
-    }
     List<Task> tasks = daoHandler.getTaskHandler().getByStatus(statusId);
-    for(Task task : tasks){
-      task.setStatus(altStatus);
+    if (removeAll) {
+      tasks.forEach(task -> taskStorage.delete(taskStorage.getTaskById(task.getId())));
+    } else {
+      Project project = st.getProject();
+      Status altStatus = findAltStatus(st, project);
+      if (altStatus == null) {
+        throw new NotAllowedOperationOnEntityException(statusId, Status.class, "Delete last status");
+      }
+      for (Task task : tasks) {
+        task.setStatus(altStatus);
+      }
+      daoHandler.getTaskHandler().updateAll(tasks);
     }
-    daoHandler.getTaskHandler().updateAll(tasks);
-    //
-    st.setProject(null);
-    handler.delete(st);
+    daoHandler.getStatusHandler().delete(st);
   }
 
   @Override

--- a/services/src/main/java/org/exoplatform/task/storage/impl/TaskStorageImpl.java
+++ b/services/src/main/java/org/exoplatform/task/storage/impl/TaskStorageImpl.java
@@ -17,15 +17,21 @@
 package org.exoplatform.task.storage.impl;
 
 import io.meeds.task.search.TaskSearchConnector;
+
+import lombok.SneakyThrows;
+
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.exoplatform.commons.utils.ListAccess;
+import org.exoplatform.container.component.RequestLifeCycle;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 import org.exoplatform.task.dao.DAOHandler;
 import org.exoplatform.task.dao.OrderBy;
 import org.exoplatform.task.dao.TaskQuery;
 import org.exoplatform.task.domain.ChangeLog;
+import org.exoplatform.task.domain.Comment;
+import org.exoplatform.task.domain.LabelTaskMapping;
 import org.exoplatform.task.domain.Status;
 import org.exoplatform.task.domain.Task;
 import org.exoplatform.task.dto.ChangeLogEntry;
@@ -94,8 +100,27 @@ public class TaskStorageImpl implements TaskStorage {
     }
 
     @Override
+    @SneakyThrows
     public void delete(TaskDto task) {
-        daoHandler.getTaskHandler().delete(StorageUtil.taskToEntity(task));
+      long taskId = task.getId();
+      ListAccess<LabelTaskMapping> labels = daoHandler.getLabelTaskMappingHandler().findLabelMappings(taskId);
+      int labelsSize = labels == null ? 0 : labels.getSize();
+      if (labelsSize > 0) {
+        daoHandler.getLabelTaskMappingHandler().deleteAll(Arrays.asList(labels.load(0, labelsSize)));
+      }
+      ListAccess<Comment> comments = daoHandler.getCommentHandler().findComments(taskId);
+      int commentsSize = comments == null ? 0 : comments.getSize();
+      if (commentsSize > 0) {
+        daoHandler.getCommentHandler().deleteAll(Arrays.asList(comments.load(0, commentsSize)));
+      }
+      ListAccess<ChangeLog> logs = daoHandler.getTaskLogHandler().findTaskLogs(taskId);
+      int logsSize = logs == null ? 0 : logs.getSize();
+      if (logsSize > 0) {
+        daoHandler.getTaskLogHandler().deleteAll(Arrays.asList(logs.load(0, logsSize)));
+      }
+      RequestLifeCycle.restartTransaction();
+      Task taskEntity = daoHandler.getTaskHandler().find(taskId);
+      daoHandler.getTaskHandler().delete(taskEntity);
     }
 
     @Override

--- a/services/src/test/java/org/exoplatform/task/dao/TestCommentDAO.java
+++ b/services/src/test/java/org/exoplatform/task/dao/TestCommentDAO.java
@@ -78,7 +78,12 @@ public class TestCommentDAO extends AbstractTest {
     comment = comments[0];
     Assert.assertEquals(username, comment.getAuthor());
 
-    //Assert.assertEquals(task.getId(), comment.getTask().getId());
+    taskDAO.update(task);
+    listComments = commentDAO.findComments(task.getId());
+    comments = ListUtil.load(listComments, 0, -1);
+    Assert.assertEquals(1, comments.length);
+    comment = comments[0];
+    Assert.assertEquals(username, comment.getAuthor());
   }
 
   @Test

--- a/services/src/test/java/org/exoplatform/task/dao/TestTaskDAO.java
+++ b/services/src/test/java/org/exoplatform/task/dao/TestTaskDAO.java
@@ -77,11 +77,13 @@ public class TestTaskDAO extends AbstractTest {
   public void setup() {
     PortalContainer container = PortalContainer.getInstance();
 
-    daoHandler = (DAOHandler) container.getComponentInstanceOfType(DAOHandler.class);
+    daoHandler = container.getComponentInstanceOfType(DAOHandler.class);
     tDAO = daoHandler.getTaskHandler();
     cDAO = daoHandler.getCommentHandler();
     labelHandler = daoHandler.getLabelHandler();
     taskSearchConnector = container.getComponentInstanceOfType(TaskSearchConnector.class);
+    projectStorage = container.getComponentInstanceOfType(ProjectStorage.class);
+    userService = container.getComponentInstanceOfType(UserService.class);
     taskStorage = new TaskStorageImpl(daoHandler, userService, projectStorage, taskSearchConnector);
     taskService = new TaskServiceImpl(taskStorage, daoHandler, listenerService);
   }
@@ -231,7 +233,7 @@ public class TestTaskDAO extends AbstractTest {
     tDAO.create(task);
 
     TaskQuery query = new TaskQuery();
-    query.setEmptyField("lblMapping");
+    query.setEmptyField("labels");
     ListAccess<Task> tasks = tDAO.findTasks(query);
     Assert.assertEquals(1, tasks.getSize());
     
@@ -405,7 +407,7 @@ public class TestTaskDAO extends AbstractTest {
     //
     endRequestLifecycle();
     initializeContainerAndStartRequestLifecycle();
-    tDAO.delete(tDAO.find(task.getId()));
+    taskStorage.delete(taskStorage.getTaskById(task.getId()));
     labels = labelHandler.findLabelsByTask(task.getId(), project.getId());
     Assert.assertEquals(0, labels.getSize());
   }

--- a/services/src/test/java/org/exoplatform/task/rest/TestProjectRestService.java
+++ b/services/src/test/java/org/exoplatform/task/rest/TestProjectRestService.java
@@ -574,7 +574,7 @@ public class TestProjectRestService {
     when(projectService.getProject(projectDto.getId())).thenReturn(projectDto);
 
     Response response1 = projectRestService.deleteProject(projectDto.getId(), false, 0, 0);
-    assertEquals(Response.Status.OK.getStatusCode(), response1.getStatus());
+    assertEquals(Response.Status.NO_CONTENT.getStatusCode(), response1.getStatus());
   }
 
   @Test

--- a/services/src/test/java/org/exoplatform/task/service/LabelServiceTest.java
+++ b/services/src/test/java/org/exoplatform/task/service/LabelServiceTest.java
@@ -16,6 +16,27 @@
  */
 package org.exoplatform.task.service;
 
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.MockitoJUnitRunner;
+
 import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.container.PortalContainer;
 import org.exoplatform.services.listener.ListenerService;
@@ -38,24 +59,10 @@ import org.exoplatform.task.storage.impl.LabelStorageImpl;
 import org.exoplatform.task.storage.impl.ProjectStorageImpl;
 import org.exoplatform.task.storage.impl.StatusStorageImpl;
 import org.exoplatform.task.storage.impl.TaskStorageImpl;
-import io.meeds.task.search.TaskSearchConnector;
 import org.exoplatform.task.util.StorageUtil;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
-import org.mockito.Mock;
-import org.mockito.MockedStatic;
-import org.mockito.junit.MockitoJUnitRunner;
 
-import java.util.Arrays;
-import java.util.Collections;
-
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.*;
+import io.meeds.task.domain.LabelField;
+import io.meeds.task.search.TaskSearchConnector;
 
 @RunWith(MockitoJUnitRunner.Silent.class)
 public class LabelServiceTest {
@@ -106,7 +113,7 @@ public class LabelServiceTest {
         PortalContainer container = PortalContainer.getInstance();
         projectStorage = new ProjectStorageImpl(daoHandler);
         taskStorage = new TaskStorageImpl(daoHandler,userService,projectStorage, taskSearchConnector);
-        statusStorage = new StatusStorageImpl(daoHandler, projectStorage);
+        statusStorage = new StatusStorageImpl(daoHandler, taskStorage, projectStorage);
         statusService = new StatusServiceImpl(daoHandler, statusStorage, projectStorage, listenerService);
         labelStorage = new LabelStorageImpl(daoHandler);
         labelService = new LabelServiceImpl(labelStorage, daoHandler, projectStorage, listenerService);
@@ -167,7 +174,7 @@ public class LabelServiceTest {
         label.setName("exo");
         Label labelEntity = StorageUtil.labelToEntity(label);
         when(daoHandler.getLabelHandler().update(any())).thenReturn(labelEntity);
-        labelService.updateLabel(label, Arrays.asList(Label.FIELDS.NAME));
+        labelService.updateLabel(label, Arrays.asList(LabelField.NAME));
         verify(labelHandler, times(1)).update(labelCaptor.capture());
 
         assertEquals("exo", labelCaptor.getValue().getName());
@@ -181,7 +188,7 @@ public class LabelServiceTest {
         label.setColor("white");
         Label labelEntity = StorageUtil.labelToEntity(label);
         when(daoHandler.getLabelHandler().update(any())).thenReturn(labelEntity);
-        labelService.updateLabel(label, Arrays.asList(Label.FIELDS.COLOR));
+        labelService.updateLabel(label, Arrays.asList(LabelField.COLOR));
         verify(labelHandler, times(1)).update(labelCaptor.capture());
 
         assertEquals("white", labelCaptor.getValue().getColor());
@@ -200,7 +207,7 @@ public class LabelServiceTest {
         label.setId(labelId);
         when(daoHandler.getLabelHandler().find(labelId)).thenReturn(label);
         when(daoHandler.getLabelHandler().update(argThat(l -> l.getId() == labelId))).thenReturn(label);
-        labelService.updateLabel(labelDto, Collections.singletonList(Label.FIELDS.PARENT));
+        labelService.updateLabel(labelDto, Collections.singletonList(LabelField.PARENT));
         verify(labelHandler, times(1)).update(labelCaptor.capture());
 
         assertEquals(labelDto.getParent(), StorageUtil.labelToDto(labelCaptor.getValue().getParent()));
@@ -214,7 +221,7 @@ public class LabelServiceTest {
         label.setHidden(true);
         Label labelEntity = StorageUtil.labelToEntity(label);
         when(daoHandler.getLabelHandler().update(any())).thenReturn(labelEntity);
-        labelService.updateLabel(label, Arrays.asList(Label.FIELDS.HIDDEN));
+        labelService.updateLabel(label, Arrays.asList(LabelField.HIDDEN));
         verify(labelHandler, times(1)).update(labelCaptor.capture());
 
         assertEquals(true, labelCaptor.getValue().isHidden());

--- a/services/src/test/java/org/exoplatform/task/service/ProjectServiceTest.java
+++ b/services/src/test/java/org/exoplatform/task/service/ProjectServiceTest.java
@@ -105,12 +105,14 @@ public class ProjectServiceTest {
     @Before
     public void setUp() {
         // Make sure the container is started to prevent the ExoTransactional annotation to fail
-        PortalContainer.getInstance();
+        PortalContainer container = PortalContainer.getInstance();
         projectStorage = new ProjectStorageImpl(daoHandler);
-        statusStorage = new StatusStorageImpl(daoHandler, projectStorage);
+        taskStorage = container.getComponentInstanceOfType(TaskStorage.class);
+        statusStorage = new StatusStorageImpl(daoHandler, taskStorage, projectStorage);
         projectService = new ProjectServiceImpl(statusService, taskService, daoHandler, projectStorage, listenerService);
         //Mock DAO handler to return Mocked DAO
         when(daoHandler.getProjectHandler()).thenReturn(projectHandler);
+        when(daoHandler.getStatusHandler()).thenReturn(statusHandler);
 
         //Mock some DAO methods
         when(projectHandler.create(any(Project.class))).thenReturn(TestUtils.getDefaultProject());

--- a/services/src/test/java/org/exoplatform/task/service/StatusServiceTest.java
+++ b/services/src/test/java/org/exoplatform/task/service/StatusServiceTest.java
@@ -101,8 +101,9 @@ public class StatusServiceTest {
     public void setUp() {
         // Make sure the container is started to prevent the ExoTransactional annotation to fail
       container = PortalContainer.getInstance();
-        projectStorage = new ProjectStorageImpl(daoHandler);
-        statusStorage = new StatusStorageImpl(daoHandler, projectStorage);
+      projectStorage = new ProjectStorageImpl(daoHandler);
+      taskStorage = container.getComponentInstanceOfType(TaskStorage.class);
+        statusStorage = new StatusStorageImpl(daoHandler, taskStorage, projectStorage);
         statusService = new StatusServiceImpl(daoHandler, statusStorage, projectStorage, listenerService);
 
         containerContext = mockStatic(ExoContainerContext.class);

--- a/services/src/test/java/org/exoplatform/task/service/TaskServiceTest.java
+++ b/services/src/test/java/org/exoplatform/task/service/TaskServiceTest.java
@@ -52,9 +52,11 @@ import org.exoplatform.task.TestDtoUtils;
 import org.exoplatform.task.TestUtils;
 import org.exoplatform.task.dao.CommentHandler;
 import org.exoplatform.task.dao.DAOHandler;
+import org.exoplatform.task.dao.LabelTaskMappingHandler;
 import org.exoplatform.task.dao.ProjectHandler;
 import org.exoplatform.task.dao.StatusHandler;
 import org.exoplatform.task.dao.TaskHandler;
+import org.exoplatform.task.dao.TaskLogHandler;
 import org.exoplatform.task.domain.Task;
 import org.exoplatform.task.dto.TaskDto;
 import org.exoplatform.task.exception.EntityNotFoundException;
@@ -74,44 +76,50 @@ public class TaskServiceTest {
 
   MockedStatic<ExoContainerContext> containerContext;
 
-  TaskService          taskService;
+  TaskService                       taskService;
 
-  TaskStorage          taskStorage;
+  TaskStorage                       taskStorage;
 
-  StatusStorage        statusStorage;
+  StatusStorage                     statusStorage;
 
-  ListenerService      listenerService;
+  ListenerService                   listenerService;
 
-  TaskSearchConnector  taskSearchConnector;
-
-  @Mock
-  TaskHandler          taskHandler;
+  TaskSearchConnector               taskSearchConnector;
 
   @Mock
-  ProjectHandler       projectHandler;
+  TaskHandler                       taskHandler;
 
   @Mock
-  StatusHandler        statusHandler;
+  ProjectHandler                    projectHandler;
 
   @Mock
-  CommentHandler       commentHandler;
+  LabelTaskMappingHandler           labelTaskMappingHandler;
 
   @Mock
-  StatusService        statusService;
+  StatusHandler                     statusHandler;
 
   @Mock
-  ProjectStorage       projectStorage;
+  CommentHandler                    commentHandler;
 
   @Mock
-  DAOHandler           daoHandler;
+  TaskLogHandler                    taskLogHandler;
 
   @Mock
-  UserService          userService;
+  StatusService                     statusService;
+
+  @Mock
+  ProjectStorage                    projectStorage;
+
+  @Mock
+  DAOHandler                        daoHandler;
+
+  @Mock
+  UserService                       userService;
 
   // ArgumentCaptors are how you can retrieve objects that were passed into a
   // method call
   @Captor
-  ArgumentCaptor<Task> taskCaptor;
+  ArgumentCaptor<Task>              taskCaptor;
 
   PortalContainer                   container;
 
@@ -141,6 +149,9 @@ public class TaskServiceTest {
     when(daoHandler.getTaskHandler()).thenReturn(taskHandler);
     when(daoHandler.getStatusHandler()).thenReturn(statusHandler);
     when(daoHandler.getProjectHandler()).thenReturn(projectHandler);
+    when(daoHandler.getLabelTaskMappingHandler()).thenReturn(labelTaskMappingHandler);
+    when(daoHandler.getCommentHandler()).thenReturn(commentHandler);
+    when(daoHandler.getTaskLogHandler()).thenReturn(taskLogHandler);
 
     // Mock some DAO methods
     when(taskHandler.create(any(Task.class))).thenReturn(TestUtils.getDefaultTask());


### PR DESCRIPTION
Prior to this change, when updating a Task Entity, the related relations and entities are removed as well.

This happens because of a **uncommon usage** of JPA Entity Cloning Strategy used in Tasks Project only which consists of returning a **clone** of JPA entity without its associations rather than returning the **original JPA Entity**. When this strategy is **coupled** with `orphanRemoval=true` on JPA entity, all associations are removed automatically when updating a Task (associated labels, logs and comments).

This change will remove the usage of `orphanRemoval=true` and will rework the way to remove Task Objects (Project, Task and Status) with **explicit removal queries** of associations rather than automatic removal.

Resolves Meeds-io/meeds#3493