### PR TITLE
fix: Add a hidden span text next to the icon task comments - MEED-9862

### DIFF
--- a/webapps/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TaskViewCard.vue
+++ b/webapps/src/main/webapp/vue-app/tasks-management/components/ProjectTasks/TaskViewCard.vue
@@ -79,6 +79,7 @@
               @click="openTaskDrawer()">
               <i class="far fa-comment uiCommentIcon"></i>
               <span class="taskCommentNumber caption">{{ task.commentCount }}</span>
+              <span class="screen-reader-only">{{ $t('label.comments') }}</span>
             </div>
             <div
               v-if="task.labels && task.labels.length"


### PR DESCRIPTION
This change will add a hidden span text next to the icon task comments .
