### PR TITLE
fix: Fix excerpt trimming when text is not actually truncated - MEED-10145 - Meeds-io/meeds#3995

### DIFF
--- a/services/src/main/java/org/exoplatform/task/integration/notification/MailTemplateProvider.java
+++ b/services/src/main/java/org/exoplatform/task/integration/notification/MailTemplateProvider.java
@@ -460,12 +460,14 @@ public class MailTemplateProvider extends TemplateProvider {
     }
 
     String cut = out.toString();
-    int lastSpace = cut.lastIndexOf(" ");
-    if (lastSpace > 0) {
-      cut = cut.substring(0, lastSpace);
+    if (wasTruncated) {
+      int lastSpace = cut.lastIndexOf(" ");
+      if (lastSpace > 0) {
+        cut = cut.substring(0, lastSpace);
+      }
+      cut = cut + "...";
     }
-
-    return wasTruncated ? cut + "..." : cut;
+    return cut;
   }
 
   private static boolean isOpeningTag(String tag) {


### PR DESCRIPTION
Prior to this change, `getExcerptPreserveHtml` was always trimming the output at the last space, even when the original text length did not exceed the configured maxTextLen. This caused the last word to be removed unnecessarily in cases where the text was already within the allowed length or contained no trailing space near the end.
This change ensures that trimming at the last space and appending "..." only occur when the text is actually truncated, preserving the full content otherwise.
