### PR TITLE
fix: Align vertically project cards to the CTA - MEED-10161 - Meeds-io/meeds#4015

### DIFF
--- a/webapps/src/main/webapp/vue-app/tasks-management/components/Project/ProjectCard.vue
+++ b/webapps/src/main/webapp/vue-app/tasks-management/components/Project/ProjectCard.vue
@@ -17,7 +17,7 @@
 <template>
   <div id="projectCard">
     <v-flex :class="flipCard && 'taskCardFlip taskCardFlipped' || 'taskCardFlip'">
-      <div class="taskCardFront py-3 px-2">
+      <div class="taskCardFront py-3 pe-4">
         <project-card-front
           :project="project"
           @openDrawer="openEditDrawer"
@@ -25,7 +25,7 @@
           @refreshProjects="refreshProjects"
           @flip="flipCard = true; flip()" />
       </div>
-      <div class="tasksCardBack pa-3">
+      <div class="tasksCardBack py-3 pe-4">
         <project-card-Reverse
           ref="reversCard"
           :project="project"

--- a/webapps/src/main/webapp/vue-app/tasks-management/components/Project/ProjectCardList.vue
+++ b/webapps/src/main/webapp/vue-app/tasks-management/components/Project/ProjectCardList.vue
@@ -39,7 +39,7 @@
     </div>
     <div v-else>
       <v-card flat class="transparent">
-        <v-item-group class="pa-4">
+        <v-item-group class="py-4">
           <v-container class="full-width pa-0">
             <v-row class="ma-0 border-box-sizing">
               <v-col


### PR DESCRIPTION
This change will align project cards vertically with the “Add project” CTA.