### PR TITLE
fix: Empty email content when comments include user mentions - MEED-10145 - Meeds-io/meeds#3995

### DIFF
--- a/services/src/main/java/org/exoplatform/task/integration/notification/MailTemplateProvider.java
+++ b/services/src/main/java/org/exoplatform/task/integration/notification/MailTemplateProvider.java
@@ -20,14 +20,7 @@ package org.exoplatform.task.integration.notification;
 
 import java.io.IOException;
 import java.io.Writer;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
+import java.util.*;
 
 import org.gatein.common.text.EntityEncoder;
 
@@ -97,7 +90,7 @@ public class MailTemplateProvider extends TemplateProvider {
       String projectUrl = notification.getValueOwnerParameter(NotificationUtils.PROJECT_URL);
       String assignee = notification.getValueOwnerParameter(NotificationUtils.TASK_ASSIGNEE);
       String listOfCoworker = notification.getValueOwnerParameter(NotificationUtils.TASK_COWORKERS);
-      commentText = CommentUtil.formatMention(getExcerpt(commentText, 130), language);
+      commentText = CommentUtil.formatMention(getExcerptPreserveHtml(commentText, 130), language);
       String coworker = notification.getValueOwnerParameter(NotificationUtils.ADDED_COWORKER);
       String usersMentioned = notification.getValueOwnerParameter(NotificationUtils.MENTIONED_USERS);
       String actionName = notification.getValueOwnerParameter(NotificationUtils.ACTION_NAME.getKey());
@@ -417,4 +410,104 @@ public class MailTemplateProvider extends TemplateProvider {
     }
   }
 
+  private static String getExcerptPreserveHtml(String html, int maxTextLen) {
+    if (html == null || maxTextLen <= 0) {
+      return "";
+    }
+
+    StringBuilder out = new StringBuilder();
+    Deque<String> openTags = new ArrayDeque<>();
+
+    int textCount = 0;
+    boolean inTag = false;
+    boolean wasTruncated = false;
+
+    StringBuilder currentTag = new StringBuilder();
+    for (int i = 0; i < html.length() && !wasTruncated; i++) {
+      char c = html.charAt(i);
+
+      if (inTag) {
+        currentTag.append(c);
+        out.append(c);
+
+        if (c == '>') {
+          inTag = false;
+          String tag = currentTag.toString();
+
+          if (isOpeningTag(tag)) {
+            String name = extractTagName(tag);
+            openTags.push(name);
+          } else if (isClosingTag(tag) && !openTags.isEmpty()) {
+            openTags.pop();
+          }
+        }
+      } else if (c == '<') {
+        inTag = true;
+        currentTag.setLength(0);
+        currentTag.append(c);
+        out.append(c);
+      } else {
+        out.append(c);
+        textCount++;
+        if (textCount >= maxTextLen) {
+          wasTruncated = true;
+        }
+      }
+    }
+
+    while (!openTags.isEmpty()) {
+      out.append("</").append(openTags.pop()).append(">");
+    }
+
+    String cut = out.toString();
+    if (wasTruncated) {
+      int lastSpace = cut.lastIndexOf(" ");
+      if (lastSpace > 0) {
+        cut = cut.substring(0, lastSpace);
+      }
+      cut = cut + "...";
+    }
+    return cut;
+  }
+
+  private static boolean isOpeningTag(String tag) {
+    if (tag == null) return false;
+
+    tag = tag.trim();
+    if (tag.length() < 3 || tag.charAt(0) != '<' || tag.charAt(tag.length() - 1) != '>') {
+      return false;
+    }
+
+    String inner = tag.substring(1, tag.length() - 1).trim();
+    if (inner.isEmpty() || inner.charAt(0) == '/' || inner.charAt(0) == '!') {
+      return false;
+    }
+
+    return !inner.endsWith("/");
+  }
+
+  private static boolean isClosingTag(String tag) {
+    if (tag == null) {
+      return false;
+    }
+    tag = tag.trim();
+    return tag.startsWith("</") && tag.endsWith(">") && tag.length() > 3;
+  }
+
+  private static String extractTagName(String tag) {
+    String inner = tag.substring(1, tag.length() - 1).trim();
+
+    int spaceIndex = inner.indexOf(' ');
+    int slashIndex = inner.indexOf('/');
+
+    int endIndex = inner.length();
+    if (spaceIndex > 0) {
+      endIndex = Math.min(endIndex, spaceIndex);
+    }
+    if (slashIndex > 0) {
+      endIndex = Math.min(endIndex, slashIndex);
+    }
+
+    return inner.substring(0, endIndex);
+  }
 }

--- a/services/src/test/java/org/exoplatform/task/integration/notification/MailTemplateProviderTest.java
+++ b/services/src/test/java/org/exoplatform/task/integration/notification/MailTemplateProviderTest.java
@@ -100,4 +100,27 @@ public class MailTemplateProviderTest extends TestCase {
     }
     return null;
   }
+
+  public void testGetExcerptPreserveHtmlWithMentions() throws Exception {
+    UserService userService = Mockito.mock(UserService.class);
+    InitParams initParams = new InitParams();
+    MailTemplateProvider provider = new MailTemplateProvider(initParams, userService);
+
+    java.lang.reflect.Method method =
+            MailTemplateProvider.class.getDeclaredMethod("getExcerptPreserveHtml", String.class, int.class);
+    method.setAccessible(true);
+
+    String htmlComment =
+            "Hello <a class=\"mention\" data-user=\"userX\">@userX</a>, " +
+                    "this is a <b>test</b> comment for email notification.";
+
+    String excerpt = (String) method.invoke(provider, htmlComment, 18);
+
+    assertNotNull(excerpt);
+
+    assertTrue(excerpt.contains("Hello"));
+    assertTrue(excerpt.contains("<a class=\"mention\" data-user=\"userX\">@userX</a>"));
+
+    assertTrue(excerpt.endsWith("..."));
+  }
 }


### PR DESCRIPTION
Prior to this change, task email notifications were sent with empty comment content when the comment included one or more mentioned users. This happened because the excerpt generation logic incorrectly handled HTML markup introduced by mentions, causing the visible text to be truncated or skipped entirely.
This fix updates the excerpt generation to preserve HTML tags while counting only visible text characters, ensuring that comments containing mentions are correctly rendered in email notifications. As a result, task email notifications now consistently display the full comment preview, even when user mentions are present.

fixes  Meeds-io/meeds#3995