### PR TITLE
feat: Retrieve Memberships from User ACL instead of OrganizationService - MEED-10149 - Meeds-io/MIPs#240

### DIFF
--- a/services/src/main/java/org/exoplatform/task/integration/TaskCommentNotificationListener.java
+++ b/services/src/main/java/org/exoplatform/task/integration/TaskCommentNotificationListener.java
@@ -23,9 +23,9 @@ import org.exoplatform.commons.api.notification.command.NotificationCommand;
 import org.exoplatform.commons.api.notification.model.PluginKey;
 import org.exoplatform.commons.notification.impl.NotificationContextImpl;
 import org.exoplatform.container.PortalContainer;
+import org.exoplatform.portal.config.UserACL;
 import org.exoplatform.services.listener.Event;
 import org.exoplatform.services.listener.Listener;
-import org.exoplatform.services.organization.OrganizationService;
 import org.exoplatform.services.security.ConversationState;
 import org.exoplatform.task.dto.CommentDto;
 import org.exoplatform.task.dto.ProjectDto;
@@ -43,10 +43,10 @@ import java.util.Set;
 
 public class TaskCommentNotificationListener extends Listener<TaskDto, CommentDto> {
 
-  private final OrganizationService organizationService;
+  private final UserACL userAcl;
 
-  public TaskCommentNotificationListener(OrganizationService organizationService) {
-    this.organizationService = organizationService;
+  public TaskCommentNotificationListener(UserACL userAcl) {
+    this.userAcl = userAcl;
   }
 
   @Override
@@ -67,7 +67,7 @@ public class TaskCommentNotificationListener extends Listener<TaskDto, CommentDt
     ctx.append(NotificationUtils.CREATOR, creator);
 
     //. Receiver
-    Set<String> receiver = new HashSet<String>();
+    Set<String> receiver = new HashSet<>();
 
     // Task creator
       receiver.add(task.getCreatedBy());
@@ -111,7 +111,7 @@ public class TaskCommentNotificationListener extends Listener<TaskDto, CommentDt
     mentioned.remove(creator);
     if (task.getStatus() != null && task.getStatus().getProject() != null) {
       ProjectDto project = task.getStatus().getProject();
-      receiver.removeIf(user -> !ProjectUtil.isProjectParticipant(organizationService, user, project));
+      receiver.removeIf(user -> !ProjectUtil.isProjectParticipant(userAcl, user, project));
     }
     ctx.append(NotificationUtils.RECEIVERS, receiver);
     ctx.append(NotificationUtils.MENTIONED, mentioned);
@@ -120,7 +120,7 @@ public class TaskCommentNotificationListener extends Listener<TaskDto, CommentDt
   }
 
   private void dispatch(NotificationContext ctx, String... pluginId) {
-    List<NotificationCommand> commands = new ArrayList<NotificationCommand>(pluginId.length);
+    List<NotificationCommand> commands = new ArrayList<>(pluginId.length);
     for (String p : pluginId) {
       commands.add(ctx.makeCommand(PluginKey.key(p)));
     }

--- a/services/src/main/java/org/exoplatform/task/integration/notification/AbstractNotificationPlugin.java
+++ b/services/src/main/java/org/exoplatform/task/integration/notification/AbstractNotificationPlugin.java
@@ -27,7 +27,6 @@ import org.exoplatform.commons.api.notification.model.NotificationInfo;
 import org.exoplatform.commons.api.notification.plugin.BaseNotificationPlugin;
 import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.container.ExoContainer;
-import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.container.PortalContainer;
 import org.exoplatform.container.RootContainer;
 import org.exoplatform.container.component.RequestLifeCycle;
@@ -116,7 +115,7 @@ public abstract class AbstractNotificationPlugin extends BaseNotificationPlugin 
   }
 
   protected Set<String> getReceiver(TaskDto task, NotificationContext ctx) {
-    UserACL userAcl = ExoContainerContext.getService(UserACL.class);
+    UserACL userAcl = CommonsUtils.getService(UserACL.class);
     Set<String> receivers = new HashSet<>();
     if (task.getAssignee() != null && !task.getAssignee().isEmpty()) {
       receivers.add(task.getAssignee());

--- a/services/src/main/java/org/exoplatform/task/integration/notification/AbstractNotificationPlugin.java
+++ b/services/src/main/java/org/exoplatform/task/integration/notification/AbstractNotificationPlugin.java
@@ -27,12 +27,13 @@ import org.exoplatform.commons.api.notification.model.NotificationInfo;
 import org.exoplatform.commons.api.notification.plugin.BaseNotificationPlugin;
 import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.container.ExoContainer;
+import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.container.PortalContainer;
 import org.exoplatform.container.RootContainer;
 import org.exoplatform.container.component.RequestLifeCycle;
 import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.portal.config.UserACL;
 import org.exoplatform.portal.config.UserPortalConfigService;
-import org.exoplatform.services.organization.OrganizationService;
 import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceService;
 import org.exoplatform.task.dto.ProjectDto;
@@ -107,8 +108,7 @@ public abstract class AbstractNotificationPlugin extends BaseNotificationPlugin 
 
   private ExoContainer getContainer() {
     String containerName = PortalContainer.getCurrentPortalContainerName();
-    ExoContainer container = RootContainer.getInstance().getPortalContainer(containerName);
-    return container;
+    return RootContainer.getInstance().getPortalContainer(containerName);
   }
 
   private String buildProjectUrl(ProjectDto project, ExoContainer container, WebAppController controller) {
@@ -116,8 +116,8 @@ public abstract class AbstractNotificationPlugin extends BaseNotificationPlugin 
   }
 
   protected Set<String> getReceiver(TaskDto task, NotificationContext ctx) {
-    OrganizationService organizationService = CommonsUtils.getOrganizationService();
-    Set<String> receivers = new HashSet<String>();
+    UserACL userAcl = ExoContainerContext.getService(UserACL.class);
+    Set<String> receivers = new HashSet<>();
     if (task.getAssignee() != null && !task.getAssignee().isEmpty()) {
       receivers.add(task.getAssignee());
     }
@@ -135,7 +135,7 @@ public abstract class AbstractNotificationPlugin extends BaseNotificationPlugin 
     }
     if (task.getStatus() != null && task.getStatus().getProject() != null) {
       ProjectDto project = task.getStatus().getProject();
-      receivers.removeIf(user -> !ProjectUtil.isProjectParticipant(organizationService, user, project));
+      receivers.removeIf(user -> !ProjectUtil.isProjectParticipant(userAcl, user, project));
     }
     return receivers;
   }

--- a/services/src/main/java/org/exoplatform/task/util/ProjectUtil.java
+++ b/services/src/main/java/org/exoplatform/task/util/ProjectUtil.java
@@ -22,7 +22,6 @@ import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
@@ -35,17 +34,15 @@ import java.util.Map;
 import java.util.ResourceBundle;
 import java.util.Set;
 
-import org.exoplatform.commons.utils.CommonsUtils;
+import org.gatein.common.text.EntityEncoder;
+
 import org.exoplatform.commons.utils.HTMLEntityEncoder;
-import org.exoplatform.commons.utils.ListAccess;
 import org.exoplatform.container.ExoContainer;
 import org.exoplatform.container.ExoContainerContext;
+import org.exoplatform.portal.config.UserACL;
 import org.exoplatform.portal.mop.SiteKey;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
-import org.exoplatform.services.organization.Membership;
-import org.exoplatform.services.organization.OrganizationService;
-import org.exoplatform.services.organization.User;
 import org.exoplatform.services.security.ConversationState;
 import org.exoplatform.services.security.Identity;
 import org.exoplatform.services.security.MembershipEntry;
@@ -58,7 +55,6 @@ import org.exoplatform.task.exception.EntityNotFoundException;
 import org.exoplatform.task.exception.ParameterEntityException;
 import org.exoplatform.task.service.ProjectService;
 import org.exoplatform.web.controller.router.Router;
-import org.gatein.common.text.EntityEncoder;
 
 public final class ProjectUtil {
   private static final Log LOG = ExoLogger.getExoLogger(ProjectUtil.class);
@@ -675,27 +671,21 @@ public final class ProjectUtil {
     return container.getComponentInstanceOfType(ProjectService.class);
   }
 
-  public static boolean isProjectParticipant(OrganizationService organizationService,
-                                      String userName,
-                                      ProjectDto project) {
-    Collection<Membership> memberships;
-    try {
-      memberships = organizationService.getMembershipHandler().findMembershipsByUser(userName);
-    } catch (Exception e) {
-      LOG.error("Error while getting user memberships", e);
-      return false;
-    }
+  public static boolean isProjectParticipant(UserACL userAcl,
+                                             String userName,
+                                             ProjectDto project) {
     if (project.getParticipator() == null) {
       return false;
     }
     if (project.getParticipator().contains(userName)) {
       return true;
     } else {
+      Collection<MembershipEntry> memberships = userAcl.getUserIdentity(userName).getMemberships();
       for (String per : project.getParticipator()) {
         MembershipEntry entry = MembershipEntry.parse(per);
         if (entry != null) {
           boolean isParticipant = memberships.stream()
-                                             .map(Membership::getGroupId)
+                                             .map(MembershipEntry::getGroup)
                                              .anyMatch(groupId -> groupId.equals(entry.getGroup()));
           if (isParticipant) {
             return true;

--- a/services/src/test/java/org/exoplatform/task/integration/notification/AbstractNotificationPluginTest.java
+++ b/services/src/test/java/org/exoplatform/task/integration/notification/AbstractNotificationPluginTest.java
@@ -22,7 +22,7 @@ import org.exoplatform.commons.api.notification.NotificationContext;
 import org.exoplatform.commons.notification.impl.NotificationContextImpl;
 import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.container.xml.InitParams;
-import org.exoplatform.services.organization.OrganizationService;
+import org.exoplatform.portal.config.UserACL;
 import org.exoplatform.task.dto.ProjectDto;
 import org.exoplatform.task.dto.StatusDto;
 import org.exoplatform.task.dto.TaskDto;
@@ -47,7 +47,7 @@ import static org.mockito.Mockito.*;
 public class AbstractNotificationPluginTest {
 
   @Mock
-  private OrganizationService organizationService;
+  private UserACL userACL;
 
   public class DummyNotificationPlugin extends AbstractNotificationPlugin {
 
@@ -74,8 +74,7 @@ public class AbstractNotificationPluginTest {
   public void setUp() throws Exception {
     commonsUtils = mockStatic(CommonsUtils.class);
     projectUtil = mockStatic(ProjectUtil.class);
-
-    commonsUtils.when(() -> CommonsUtils.getOrganizationService()).thenReturn(organizationService);
+    commonsUtils.when(() -> CommonsUtils.getService(UserACL.class)).thenReturn(userACL);
   }
 
   @After
@@ -96,7 +95,7 @@ public class AbstractNotificationPluginTest {
     AbstractNotificationPlugin notificationPlugin = new DummyNotificationPlugin(new InitParams());
 
     // When
-    projectUtil.when(() -> ProjectUtil.isProjectParticipant(organizationService,"user1", projectDto)).thenReturn(true);
+    projectUtil.when(() -> ProjectUtil.isProjectParticipant(userACL,"user1", projectDto)).thenReturn(true);
     Set<String> receivers = notificationPlugin.getReceiver(task, null);
 
     // Then
@@ -118,8 +117,8 @@ public class AbstractNotificationPluginTest {
     AbstractNotificationPlugin notificationPlugin = new DummyNotificationPlugin(new InitParams());
 
     // When
-    projectUtil.when(() -> ProjectUtil.isProjectParticipant(organizationService,"user1", projectDto)).thenReturn(true);
-    projectUtil.when(() -> ProjectUtil.isProjectParticipant(organizationService,"user2", projectDto)).thenReturn(true);
+    projectUtil.when(() -> ProjectUtil.isProjectParticipant(userACL,"user1", projectDto)).thenReturn(true);
+    projectUtil.when(() -> ProjectUtil.isProjectParticipant(userACL,"user2", projectDto)).thenReturn(true);
 
     Set<String> receivers = notificationPlugin.getReceiver(task, null);
 
@@ -143,8 +142,8 @@ public class AbstractNotificationPluginTest {
     AbstractNotificationPlugin notificationPlugin = new DummyNotificationPlugin(new InitParams());
 
     // When
-    projectUtil.when(() -> ProjectUtil.isProjectParticipant(organizationService,"user1", projectDto)).thenReturn(true);
-    projectUtil.when(() -> ProjectUtil.isProjectParticipant(organizationService,"user2", projectDto)).thenReturn(true);
+    projectUtil.when(() -> ProjectUtil.isProjectParticipant(userACL,"user1", projectDto)).thenReturn(true);
+    projectUtil.when(() -> ProjectUtil.isProjectParticipant(userACL,"user2", projectDto)).thenReturn(true);
     Set<String> receivers = notificationPlugin.getReceiver(task, null);
 
     // Then
@@ -171,9 +170,9 @@ public class AbstractNotificationPluginTest {
     AbstractNotificationPlugin notificationPlugin = new DummyNotificationPlugin(new InitParams());
 
     // When
-    projectUtil.when(() -> ProjectUtil.isProjectParticipant(organizationService,"user1", projectDto)).thenReturn(true);
-    projectUtil.when(() -> ProjectUtil.isProjectParticipant(organizationService,"user2", projectDto)).thenReturn(true);
-    projectUtil.when(() -> ProjectUtil.isProjectParticipant(organizationService,"user3", projectDto)).thenReturn(true);
+    projectUtil.when(() -> ProjectUtil.isProjectParticipant(userACL,"user1", projectDto)).thenReturn(true);
+    projectUtil.when(() -> ProjectUtil.isProjectParticipant(userACL,"user2", projectDto)).thenReturn(true);
+    projectUtil.when(() -> ProjectUtil.isProjectParticipant(userACL,"user3", projectDto)).thenReturn(true);
 
     Set<String> receivers = notificationPlugin.getReceiver(task, ctx);
 
@@ -201,8 +200,8 @@ public class AbstractNotificationPluginTest {
     AbstractNotificationPlugin notificationPlugin = new DummyNotificationPlugin(new InitParams());
 
     // When
-    projectUtil.when(() -> ProjectUtil.isProjectParticipant(organizationService, "user1", projectDto)).thenReturn(false);
-    projectUtil.when(() -> ProjectUtil.isProjectParticipant(organizationService, "user2", projectDto)).thenReturn(true);
+    projectUtil.when(() -> ProjectUtil.isProjectParticipant(userACL, "user1", projectDto)).thenReturn(false);
+    projectUtil.when(() -> ProjectUtil.isProjectParticipant(userACL, "user2", projectDto)).thenReturn(true);
 
     Set<String> receivers = notificationPlugin.getReceiver(task, ctx);
 


### PR DESCRIPTION
This change will centralize the users memberships retrieval to be made from `UserACL` Service rather than `OrganizationService`. This centralization will allow to optimize the Code enhancements and evolutivity.