### PR TITLE
feat: Allow to Retrieve Tasks Ordered by Last Activity - EXO-84071 - Meeds-io/ai#65

### DIFF
--- a/services/src/main/java/org/exoplatform/task/dao/CommentHandler.java
+++ b/services/src/main/java/org/exoplatform/task/dao/CommentHandler.java
@@ -34,4 +34,10 @@ public interface CommentHandler extends GenericDAO<Comment, Long> {
 
   int countCommentsWithSubs(long taskId);
 
+  /**
+   * @param taskId Task Technical identifier
+   * @return null if no comments else last created comment on task
+   */
+  Comment getLastComment(long taskId);
+
 }

--- a/services/src/main/java/org/exoplatform/task/dao/TaskHandler.java
+++ b/services/src/main/java/org/exoplatform/task/dao/TaskHandler.java
@@ -108,5 +108,14 @@ public interface TaskHandler extends GenericDAO<Task, Long> {
    * @return a list of task IDs
    */
   List<Long> getAllIds(int offset, int limit);
-}
 
+  /**
+   * Find tasks switch last update date computed from Task Logs and Task
+   * Comments after applying the {@link TaskQuery} filtering
+   * 
+   * @param query {@link TaskQuery}
+   * @return {@link List} of corresponding Tasks
+   */
+  ListAccess<Task> findLastUpdatedTasks(TaskQuery query);
+
+}

--- a/services/src/main/java/org/exoplatform/task/dao/jpa/CommentDAOImpl.java
+++ b/services/src/main/java/org/exoplatform/task/dao/jpa/CommentDAOImpl.java
@@ -18,7 +18,7 @@
  */
 package org.exoplatform.task.dao.jpa;
 
-import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.CollectionUtils;
 
 import org.exoplatform.commons.api.persistence.ExoTransactional;
 import org.exoplatform.commons.utils.ListAccess;
@@ -68,6 +68,18 @@ public class CommentDAOImpl extends CommonJPADAO<Comment, Long> implements Comme
     count.setParameter("taskId", taskId);
 
     return new JPAQueryListAccess<Comment>(Comment.class, count, query);
+  }
+
+  @Override
+  public Comment getLastComment(long taskId) {
+    TypedQuery<Comment> query = getEntityManager().createNamedQuery("Comment.findLastCommentOfTask", Comment.class);
+    query.setParameter("taskId", taskId);
+    List<Comment> result = query.getResultList();
+    if (CollectionUtils.isEmpty(result)) {
+      return null;
+    } else {
+      return result.get(0);
+    }
   }
 
   @Override

--- a/services/src/main/java/org/exoplatform/task/dao/jpa/CommonJPADAO.java
+++ b/services/src/main/java/org/exoplatform/task/dao/jpa/CommonJPADAO.java
@@ -22,6 +22,7 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.Tuple;
 import jakarta.persistence.TypedQuery;
 import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaBuilder.Case;
 import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.Expression;
 import jakarta.persistence.criteria.Join;
@@ -31,10 +32,12 @@ import jakarta.persistence.criteria.Path;
 import jakarta.persistence.criteria.Predicate;
 import jakarta.persistence.criteria.Root;
 import jakarta.persistence.criteria.Selection;
+import jakarta.persistence.criteria.Subquery;
 
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -46,6 +49,9 @@ import org.exoplatform.task.dao.Query;
 import org.exoplatform.task.dao.condition.AggregateCondition;
 import org.exoplatform.task.dao.condition.Condition;
 import org.exoplatform.task.dao.condition.SingleCondition;
+import org.exoplatform.task.domain.ChangeLog;
+import org.exoplatform.task.domain.Comment;
+import org.exoplatform.task.domain.Task;
 
 public abstract class CommonJPADAO<E, K extends Serializable> extends GenericDAOJPAImpl<E, K> {  
   
@@ -116,17 +122,45 @@ public abstract class CommonJPADAO<E, K extends Serializable> extends GenericDAO
       List<OrderBy> orderby = query.getOrderBy();
       if(orderby != null && !orderby.isEmpty()) {
         List<Order> orders = new ArrayList<>(orderby.size());
-        for(OrderBy orderBy : orderby) {
-          Expression<?> p = root.get(orderBy.getFieldName());
+        for (OrderBy orderBy : orderby) {
           Order order;
-          if (orderBy.isAscending()) {
+          if (orderBy.getFieldName().equals("lastTaskActivity")) {
+            Subquery<Date> maxCommentSq = q.subquery(Date.class);
+            Root<Comment> c = maxCommentSq.from(Comment.class);
+
+            maxCommentSq.select(cb.greatest(c.<Date> get("createdTime")));
+            maxCommentSq.where(cb.equal(c.get("task"), root));
+
+            Subquery<Date> maxLogSq = q.subquery(Date.class);
+            Root<ChangeLog> l = maxLogSq.from(ChangeLog.class);
+
+            maxLogSq.select(cb.greatest(l.<Date> get("createdTime")));
+            maxLogSq.where(cb.equal(l.get("task"), root));
+
+            Expression<Date> taskCreated = root.get("createdTime");
+            Expression<Date> maxCommentTime = cb.coalesce(maxCommentSq.getSelection(), taskCreated);
+            Expression<Date> maxLogTime = cb.coalesce(maxLogSq.getSelection(), taskCreated);
+
+            Case<Date> tmpSelectCase = cb.selectCase();
+            Expression<Date> tmpMax = tmpSelectCase.when(cb.greaterThan(taskCreated, maxCommentTime), taskCreated)
+                                                   .otherwise(maxCommentTime);
+
+            tmpSelectCase = cb.selectCase();
+            Expression<Date> lastActivity = tmpSelectCase.when(cb.greaterThan(tmpMax, maxLogTime), tmpMax)
+                                                         .otherwise(maxLogTime);
+
+            selections.add(lastActivity);
+
+            order = orderBy.isAscending() ? cb.asc(lastActivity) : cb.desc(lastActivity);
+          } else if (orderBy.isAscending()) {
+            Expression<?> p = root.get(orderBy.getFieldName());
             // NULL value should be at last when order by
             Expression<?> nullCase = cb.selectCase().when(p.isNull(), 1).otherwise(0);
             selections.add(nullCase);
             orders.add(cb.asc(nullCase));
-
             order = cb.asc(p);
           } else {
+            Expression<?> p = root.get(orderBy.getFieldName());
             order = cb.desc(p);
           }
           orders.add(order);

--- a/services/src/main/java/org/exoplatform/task/dao/jpa/TaskDAOImpl.java
+++ b/services/src/main/java/org/exoplatform/task/dao/jpa/TaskDAOImpl.java
@@ -88,6 +88,12 @@ public class TaskDAOImpl extends CommonJPADAO<Task, Long> implements TaskHandler
   }
 
   @Override
+  public ListAccess<Task> findLastUpdatedTasks(TaskQuery query) {
+    query.setOrderBy(List.of(new OrderBy("lastTaskActivity", false)));
+    return findEntities(query, Task.class);
+  }
+
+  @Override
   public <T> List<T> selectTaskField(TaskQuery query, String fieldName) {
     EntityManager em = getEntityManager();
     CriteriaBuilder cb = em.getCriteriaBuilder();

--- a/services/src/main/java/org/exoplatform/task/domain/ChangeLog.java
+++ b/services/src/main/java/org/exoplatform/task/domain/ChangeLog.java
@@ -18,6 +18,9 @@
  */
 package org.exoplatform.task.domain;
 
+import java.util.Calendar;
+import java.util.Date;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -28,6 +31,8 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.NamedQuery;
 import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
+import jakarta.persistence.Temporal;
+import jakarta.persistence.TemporalType;
 import lombok.Data;
 
 @Entity(name = "TaskChangeLog")
@@ -58,12 +63,13 @@ public class ChangeLog implements Comparable<ChangeLog> {
 
   private String target;
 
-  @Column(name="CREATED_TIME")
-  private long createdTime = System.currentTimeMillis();
+  @Temporal(TemporalType.TIMESTAMP)
+  @Column(name = "CREATED_TIME")
+  private Date   createdTime = Calendar.getInstance().getTime();
 
   @Override
   public int compareTo(ChangeLog o) {
-    return (int)(getCreatedTime() - o.getCreatedTime());
+    return getCreatedTime().compareTo(o.getCreatedTime());
   }
 
   @Override

--- a/services/src/main/java/org/exoplatform/task/domain/Comment.java
+++ b/services/src/main/java/org/exoplatform/task/domain/Comment.java
@@ -19,6 +19,7 @@
 package org.exoplatform.task.domain;
 
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
@@ -52,6 +53,8 @@ import lombok.EqualsAndHashCode;
     query = "SELECT count(c) FROM TaskComment c WHERE c.task.id = :taskId")
 @NamedQuery(name = "Comment.findCommentsOfTask",
     query = "SELECT c FROM TaskComment c WHERE c.task.id = :taskId AND c.parentComment IS NULL ORDER BY c.createdTime DESC")
+@NamedQuery(name = "Comment.findLastCommentOfTask",
+    query = "SELECT c FROM TaskComment c WHERE c.task.id = :taskId ORDER BY c.createdTime DESC")
 @NamedQuery(name = "Comment.findSubCommentsOfComments",
     query = "SELECT c FROM TaskComment c WHERE c.parentComment IN (:comments) ORDER BY c.createdTime ASC")
 @NamedQuery(name = "Comment.deleteCommentOfTask",
@@ -78,7 +81,7 @@ public class Comment {
 
   @Temporal(TemporalType.TIMESTAMP)
   @Column(name = "CREATED_TIME")
-  private Date                 createdTime;
+  private Date                 createdTime = Calendar.getInstance().getTime();
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "TASK_ID")

--- a/services/src/main/java/org/exoplatform/task/domain/Task.java
+++ b/services/src/main/java/org/exoplatform/task/domain/Task.java
@@ -19,6 +19,7 @@
 package org.exoplatform.task.domain;
 
 import java.io.Serializable;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
@@ -206,7 +207,7 @@ public class Task implements Serializable {
 
   @Temporal(TemporalType.TIMESTAMP)
   @Column(name = "CREATED_TIME")
-  private Date        createdTime;
+  private Date        createdTime = Calendar.getInstance().getTime();
 
   @Temporal(TemporalType.TIMESTAMP)
   @Column(name = "START_DATE")

--- a/services/src/main/java/org/exoplatform/task/dto/ChangeLogEntry.java
+++ b/services/src/main/java/org/exoplatform/task/dto/ChangeLogEntry.java
@@ -69,8 +69,8 @@ public class ChangeLogEntry implements Serializable {
         
         this.targetFullName = userService.loadUser(changeLog.getTarget()).getDisplayName();
         
-        this.createdTime = changeLog.getCreatedTime();
-    }
+        this.createdTime = changeLog.getCreatedTime() == null ? 0 : changeLog.getCreatedTime().getTime();
+      }
 
     public long getId() {
         return id;

--- a/services/src/main/java/org/exoplatform/task/service/CommentService.java
+++ b/services/src/main/java/org/exoplatform/task/service/CommentService.java
@@ -55,4 +55,10 @@ public interface CommentService {
    * @return {@link Integer}
    */
   int countCommentsWithSubs(long taskId);
+
+  /**
+   * @param taskId Task identifier
+   * @return null if no comments else last created comment on task
+   */
+  CommentDto getLastComment(long taskId);
 }

--- a/services/src/main/java/org/exoplatform/task/service/TaskService.java
+++ b/services/src/main/java/org/exoplatform/task/service/TaskService.java
@@ -192,4 +192,15 @@ public interface TaskService {
      * @return a list of task IDs
      */
     public List<TaskDto> findTasks(TaskSearchFilter taskFilter);
+
+    /**
+     * Find tasks switch last update date computed from Task Logs and Task
+     * Comments after applying the {@link TaskQuery} filtering
+     * 
+     * @param query {@link TaskQuery}
+     * @param offset result offset
+     * @param limit result limit
+     * @return {@link List} of corresponding Tasks
+     */
+    List<TaskDto> findLastUpdatedTasks(TaskQuery query, int offset, int limit);
 }

--- a/services/src/main/java/org/exoplatform/task/service/impl/CommentServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/task/service/impl/CommentServiceImpl.java
@@ -33,6 +33,7 @@ import org.exoplatform.task.dto.TaskDto;
 import org.exoplatform.task.exception.EntityNotFoundException;
 import org.exoplatform.task.service.CommentService;
 import org.exoplatform.task.storage.CommentStorage;
+import org.exoplatform.task.util.StorageUtil;
 
 public class CommentServiceImpl implements CommentService {
     private static final Log LOG = ExoLogger.getExoLogger(CommentServiceImpl.class);
@@ -69,6 +70,11 @@ public class CommentServiceImpl implements CommentService {
     @Override
     public int countComments(long taskId) {
         return commentStorage.countComments(taskId);
+    }
+
+    @Override
+    public CommentDto getLastComment(long taskId) {
+      return commentStorage.getLastComment(taskId);
     }
 
     @Override

--- a/services/src/main/java/org/exoplatform/task/service/impl/TaskServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/task/service/impl/TaskServiceImpl.java
@@ -162,6 +162,11 @@ public class TaskServiceImpl implements TaskService {
     }
 
     @Override
+    public List<TaskDto> findLastUpdatedTasks(TaskQuery query, int offset, int limit) {
+        return taskStorage.findLastUpdatedTasks(query, offset, limit);
+    }
+
+    @Override
     public int countTasks(TaskQuery query) throws Exception {
         return taskStorage.countTasks(query);
     }

--- a/services/src/main/java/org/exoplatform/task/storage/CommentStorage.java
+++ b/services/src/main/java/org/exoplatform/task/storage/CommentStorage.java
@@ -56,4 +56,10 @@ public interface CommentStorage {
    */
   int countCommentsWithSubs(long taskId);
 
+  /**
+   * @param taskId Task identifier
+   * @return null if no comments else last created comment on task
+   */
+  CommentDto getLastComment(long taskId);
+
 }

--- a/services/src/main/java/org/exoplatform/task/storage/TaskStorage.java
+++ b/services/src/main/java/org/exoplatform/task/storage/TaskStorage.java
@@ -18,12 +18,9 @@
  */
 package org.exoplatform.task.storage;
 
-import org.exoplatform.commons.utils.ListAccess;
 import org.exoplatform.task.dao.OrderBy;
 import org.exoplatform.task.dao.TaskQuery;
-import org.exoplatform.task.domain.ChangeLog;
 import org.exoplatform.task.domain.Status;
-import org.exoplatform.task.domain.Task;
 import org.exoplatform.task.dto.ChangeLogEntry;
 import org.exoplatform.task.dto.LabelDto;
 import org.exoplatform.task.dto.TaskDto;
@@ -175,4 +172,15 @@ public interface TaskStorage {
      * @return {@link List} of {@link TaskDto}
      */
     List<TaskDto> findTasks(TaskSearchFilter filter);
+
+    /**
+     * Find tasks switch last update date computed from Task Logs and Task
+     * Comments after applying the {@link TaskQuery} filtering
+     * 
+     * @param query {@link TaskQuery}
+     * @param offset result offset
+     * @param limit result limit
+     * @return {@link List} of corresponding Tasks
+     */
+    List<TaskDto> findLastUpdatedTasks(TaskQuery query, int offset, int limit);
 }

--- a/services/src/main/java/org/exoplatform/task/storage/impl/CommentStorageImpl.java
+++ b/services/src/main/java/org/exoplatform/task/storage/impl/CommentStorageImpl.java
@@ -61,6 +61,11 @@ public class CommentStorageImpl implements CommentStorage {
     }
 
     @Override
+    public CommentDto getLastComment(long taskId) {
+      return StorageUtil.commentToDto(daoHandler.getCommentHandler().getLastComment(taskId), projectStorage);
+    }
+
+    @Override
     public List<CommentDto> getCommentsWithSubs(long taskId, int offset, int limit) {
         try {
             List<CommentDto> commentsDto=new ArrayList<>();

--- a/services/src/main/java/org/exoplatform/task/storage/impl/TaskStorageImpl.java
+++ b/services/src/main/java/org/exoplatform/task/storage/impl/TaskStorageImpl.java
@@ -146,8 +146,19 @@ public class TaskStorageImpl implements TaskStorage {
 
     @Override
     public List<TaskDto> findTasks(TaskQuery query, int offset, int limit) throws Exception {
-        List<Task> taskEntities = Arrays.asList(daoHandler.getTaskHandler().findTasks(query).load(offset, limit));
-        return taskEntities.stream().map((Task taskEntity) -> StorageUtil.taskToDto(taskEntity,projectStorage)).collect(Collectors.toList());
+      List<Task> taskEntities = Arrays.asList(daoHandler.getTaskHandler().findTasks(query).load(offset, limit));
+      return taskEntities.stream()
+                         .map((Task taskEntity) -> StorageUtil.taskToDto(taskEntity, projectStorage))
+                         .collect(Collectors.toList());
+    }
+
+    @Override
+    @SneakyThrows
+    public List<TaskDto> findLastUpdatedTasks(TaskQuery query, int offset, int limit) {
+      List<Task> taskEntities = Arrays.asList(daoHandler.getTaskHandler().findLastUpdatedTasks(query).load(offset, limit));
+      return taskEntities.stream()
+                         .map((Task taskEntity) -> StorageUtil.taskToDto(taskEntity, projectStorage))
+                         .toList();
     }
 
     public int countTasks(TaskQuery query) throws Exception {

--- a/services/src/main/java/org/exoplatform/task/util/StorageUtil.java
+++ b/services/src/main/java/org/exoplatform/task/util/StorageUtil.java
@@ -36,6 +36,7 @@ import org.exoplatform.task.service.UserService;
 import org.exoplatform.task.storage.ProjectStorage;
 
 import java.util.Arrays;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
@@ -52,7 +53,7 @@ public final class StorageUtil{
         changeLog.setTask(changeLogEntry.getTask());
         changeLog.setAuthor(changeLogEntry.getAuthor());
         changeLog.setActionName(changeLogEntry.getActionName());
-        changeLog.setCreatedTime(changeLogEntry.getCreatedTime());
+        changeLog.setCreatedTime(new Date(changeLogEntry.getCreatedTime()));
         changeLog.setTarget(changeLogEntry.getTarget());
         return changeLog;
     }
@@ -63,7 +64,7 @@ public final class StorageUtil{
         changeLogEntry.setTask(changeLog.getTask());
         changeLogEntry.setAuthor(changeLog.getAuthor());
         changeLogEntry.setActionName(changeLog.getActionName());
-        changeLogEntry.setCreatedTime(changeLog.getCreatedTime());
+        changeLogEntry.setCreatedTime(changeLog.getCreatedTime() == null ? 0 : changeLog.getCreatedTime().getTime());
         changeLogEntry.setTarget(changeLog.getTarget());
         changeLogEntry.setAuthorFullName(userService.loadUser(changeLog.getAuthor()).getDisplayName());
         changeLogEntry.setAuthorAvatarUrl(userService.loadUser(changeLog.getAuthor()).getAvatar());

--- a/services/src/main/resources/conf/portal/configuration.xml
+++ b/services/src/main/resources/conf/portal/configuration.xml
@@ -123,6 +123,7 @@
           <value>db/changelog/task.db.changelog-3.0.0.xml</value>
           <value>db/changelog/task.db.changelog-3.1.0.xml</value>
           <value>db/changelog/task.db.changelog-3.2.0.xml</value>
+          <value>db/changelog/task.db.changelog-7.2.0.xml</value>
         </values-param>
       </init-params>
     </component-plugin>

--- a/services/src/main/resources/db/changelog/task.db.changelog-7.2.0.xml
+++ b/services/src/main/resources/db/changelog/task.db.changelog-7.2.0.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ This file is part of the Meeds project (https://meeds.io/).
+
+ Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 3 of the License, or (at your option) any later version.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public License
+ along with this program; if not, write to the Free Software Foundation,
+ Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+-->
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.9.xsd">
+  <!-- Start:: Migrate TASK_CHANGE_LOGS.CREATED_TIME to TIMESTAMP  -->
+  <!-- 1. Create new Temp Field  -->
+  <changeSet id="7.2.0-01" author="task">
+    <addColumn tableName="TASK_CHANGE_LOGS">
+      <column name="CREATED_TIME_TMP" type="TIMESTAMP" />
+    </addColumn>
+  </changeSet>
+  <!-- 2. Add Field Value -->
+  <!-- 2.1. postgres -->
+  <changeSet id="7.2.0-02" author="task" dbms="postgres">
+    <update tableName="TASK_CHANGE_LOGS">
+      <column name="CREATED_TIME_TMP" valueComputed="FROM_UNIXTIME(CREATED_TIME)"/>
+    </update>
+  </changeSet>
+  <!-- 2.2. mysql -->
+  <changeSet id="7.2.0-02" author="task" dbms="mysql">
+    <update tableName="TASK_CHANGE_LOGS">
+      <column name="CREATED_TIME_TMP" valueComputed="TO_TIMESTAMP(CREATED_TIME)"/>
+    </update>
+  </changeSet>
+  <!-- 2.3. hsqldb -->
+  <changeSet id="7.2.0-02" author="task" dbms="hsqldb">
+    <update tableName="TASK_CHANGE_LOGS">
+        <column name="CREATED_TIME_TMP" valueComputed="DATEADD('ms', CREATED_TIME, TIMESTAMP '1970-01-01 00:00:00')"/>
+    </update>
+  </changeSet>
+  <!-- 3. Drop Old Bigint Field -->
+  <changeSet id="7.2.0-03" author="task">
+    <dropColumn tableName="TASK_CHANGE_LOGS" columnName="CREATED_TIME" />
+  </changeSet>
+  <!-- 4. Rename New Timestamp Field -->
+  <changeSet id="7.2.0-04" author="task">
+    <renameColumn tableName="TASK_CHANGE_LOGS"
+                  oldColumnName="CREATED_TIME_TMP"
+                  newColumnName="CREATED_TIME"
+                  columnDataType="TIMESTAMP" />
+  </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
This change will allow to retrieve the list of Tasks ordered by the last Activity including Comment Dates, ChangeLog Dates and Task Creation Date.