### PR TITLE
fix: Move the settings icon for the tasks portlet to the end - MEED-10206 - Meeds-io/meeds#4037 

### DIFF
--- a/webapps/src/main/webapp/vue-app/tasks/components/TasksApp.vue
+++ b/webapps/src/main/webapp/vue-app/tasks/components/TasksApp.vue
@@ -38,19 +38,6 @@
             </v-btn>
             <div v-else>
               <v-btn
-                v-if="$root.canEdit"
-                :title="$t('label.editSettings')"
-                class="text-font-size"
-                small
-                link
-                icon
-                @click="openSettingsDrawer">
-                <v-icon
-                  size="18">
-                  fas fa-cog
-                </v-icon>
-              </v-btn>
-              <v-btn
                 v-if="tasksSize"
                 :title="$t('label.addTask')"
                 small
@@ -73,6 +60,19 @@
                 <v-icon
                   size="18">
                   fas fa-external-link-alt
+                </v-icon>
+              </v-btn>
+              <v-btn
+                v-if="$root.canEdit"
+                :title="$t('label.editSettings')"
+                class="text-font-size"
+                small
+                link
+                icon
+                @click="openSettingsDrawer">
+                <v-icon
+                  size="18">
+                  fas fa-cog
                 </v-icon>
               </v-btn>
             </div>


### PR DESCRIPTION
This change will move the settings icon for the tasks portlet to the end.