### PR TITLE
fix: prevent sending full user object in participants search query - MEED-10198 - Meeds-io/meeds#4023

### DIFF
--- a/webapps/src/main/webapp/vue-app/tasks-management/components/Project/ProjectAssigneeParticipator.vue
+++ b/webapps/src/main/webapp/vue-app/tasks-management/components/Project/ProjectAssigneeParticipator.vue
@@ -88,14 +88,14 @@ export default {
     canEditParticipant() {
       return !(this.project.spaceDetails||this.project.spaceName);
     },
-    searchOptions(){
-      if (this.project.spaceDetails){
+    searchOptions() {
+      if (this.project.spaceDetails) {
         return {
           spaceURL: this.project.spaceDetails.prettyName,
-          currentUser: this.currentUser
+          currentUser: false
         };
       }
-      return this.currentUser;
+      return {};
     },
     relationsType(){
       if (this.project.spaceDetails){


### PR DESCRIPTION
prior to this change, The participants suggester was not working when the current user had a long profile work experiences description.
The issue was caused by sending the full `currentUser` object in the request query string, which resulted in an oversized and invalid query.
This fix ensures that when space details are present, `currentUser` is sent as a boolean flag instead of the full object
