### PR TITLE
Fix: Task creator displays his tasks even if not allowed - MEED-10197 - Meeds-io/meeds#3979

### DIFF
--- a/services/src/main/java/org/exoplatform/task/util/TaskUtil.java
+++ b/services/src/main/java/org/exoplatform/task/util/TaskUtil.java
@@ -633,17 +633,16 @@ public final class TaskUtil {
     Identity identity = ConversationState.getCurrent().getIdentity();
     String userId = identity.getUserId();
 
-    if ((task.getAssignee() != null && task.getAssignee().equals(identity.getUserId())) ||
-        getCoworker(taskService,task.getId()).contains(userId) ||
-        (task.getCreatedBy() != null && task.getCreatedBy().equals(userId))) {
-      return true;
-    }
-
     if (task.getStatus() != null && task.getStatus().getProject() != null) {
       ProjectDto project = task.getStatus().getProject();
       if (project.canView(identity)) {
         return true;
       }
+    }
+
+    if ((task.getAssignee() != null && task.getAssignee().equals(identity.getUserId())) ||
+        getCoworker(taskService,task.getId()).contains(userId)) {
+      return true;
     }
 
     return UserUtil.isPlatformAdmin(identity);


### PR DESCRIPTION
Before this change, task creator can always access his tasks even if he's not allowed to be in case of tasks moved to another project. To fix this problem, in the hasEditPermission method, remove the check from the task creator. After this change, users will no longer be able to access /tasks/taskDetail/TASKID unless they are members of the project.