### PR TITLE
fix: restricted page need to be displayed if not allowed to display task - MEED-10264 - Meeds-io/meeds#4060

### DIFF
--- a/services/src/main/java/org/exoplatform/task/filter/TaskRedirectHandler.java
+++ b/services/src/main/java/org/exoplatform/task/filter/TaskRedirectHandler.java
@@ -1,0 +1,75 @@
+package org.exoplatform.task.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.SneakyThrows;
+import org.exoplatform.container.ExoContainerContext;
+import org.exoplatform.services.security.ConversationState;
+import org.exoplatform.services.security.Identity;
+import org.exoplatform.task.dto.ProjectDto;
+import org.exoplatform.task.dto.TaskDto;
+import org.exoplatform.task.service.ProjectService;
+import org.exoplatform.task.service.TaskService;
+import org.exoplatform.task.util.TaskUtil;
+import org.exoplatform.web.filter.Filter;
+
+import java.io.IOException;
+
+public class TaskRedirectHandler implements Filter {
+
+  @SneakyThrows
+  @Override
+  public void doFilter(ServletRequest request,
+                       ServletResponse response,
+                       FilterChain chain) {
+
+    HttpServletRequest httpRequest = (HttpServletRequest) request;
+    HttpServletResponse httpResponse = (HttpServletResponse) response;
+
+    String uri = httpRequest.getRequestURI();
+
+    if (uri == null) {
+      chain.doFilter(request, response);
+      return;
+    }
+
+    Identity identity = ConversationState.getCurrent().getIdentity();
+    if (uri.contains("/tasks/taskDetail/")) {
+      Long taskId = extractId(uri);
+      TaskService taskService = ExoContainerContext
+        .getCurrentContainer()
+        .getComponentInstanceOfType(TaskService.class);
+      TaskDto task = taskService.getTask(taskId);
+
+      if (task != null && !TaskUtil.hasViewPermission(taskService, task)) {
+        redirectToRestricted(httpRequest, httpResponse);
+        return;
+      }
+    }
+
+    if (uri.contains("/tasks/projectDetail/")) {
+      Long projectId = extractId(uri);
+      ProjectService projectService = ExoContainerContext
+        .getCurrentContainer()
+        .getComponentInstanceOfType(ProjectService.class);
+      ProjectDto project = projectService.getProject(projectId);
+
+      if (project != null && !project.canView(identity)) {
+        redirectToRestricted(httpRequest, httpResponse);
+        return;
+      }
+    }
+    chain.doFilter(request, response);
+  }
+
+  private Long extractId(String uri) {
+    return Long.parseLong(uri.substring(uri.lastIndexOf("/") + 1));
+  }
+
+  private void redirectToRestricted(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    response.sendRedirect(request.getContextPath() + "/dw/restricted-project");
+  }
+}

--- a/webapps/src/main/resources/locale/portlet/restrictedProject_en.properties
+++ b/webapps/src/main/resources/locale/portlet/restrictedProject_en.properties
@@ -1,0 +1,3 @@
+text.title=Restricted Area
+text.body=This content is exclusively restricted to a community.
+text.sub.body=You cannot access it.

--- a/webapps/src/main/webapp/WEB-INF/conf/configuration.xml
+++ b/webapps/src/main/webapp/WEB-INF/conf/configuration.xml
@@ -27,6 +27,7 @@
   <import>war:/conf/task-addon/search-configuration.xml</import>
   <import>war:/conf/task-addon/ckeditor-configuration.xml</import>
   <import>war:/conf/task-addon/indexing-configuration.xml</import>
+  <import>war:/conf/task-addon/task-service-configuration.xml</import>
 
   <import profiles="analytics">war:/conf/task-addon/analytics-configuration.xml</import>
   <import profiles="gamification">war:/conf/task-addon/gamification-integration-configuration.xml</import>

--- a/webapps/src/main/webapp/WEB-INF/conf/task-addon/task-service-configuration.xml
+++ b/webapps/src/main/webapp/WEB-INF/conf/task-addon/task-service-configuration.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<configuration xmlns="http://www.exoplatform.org/xml/ns/kernel_1_3.xsd"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="http://www.exoplatform.org/xml/ns/kernel_1_3.xsd
+                                   http://www.exoplatform.org/xml/ns/kernel_1_3.xsd">
+
+  <external-component-plugins>
+    <target-component>org.exoplatform.web.filter.ExtensibleFilter</target-component>
+    <component-plugin>
+      <name>Task redirect handler</name>
+      <set-method>addFilterDefinitions</set-method>
+      <type>org.exoplatform.web.filter.FilterDefinitionPlugin</type>
+      <priority>2</priority>
+      <init-params>
+        <object-param>
+          <name>Registered task redirect handler</name>
+          <object type="org.exoplatform.web.filter.FilterDefinition">
+            <field name="filter">
+              <object type="org.exoplatform.task.filter.TaskRedirectHandler"/>
+            </field>
+            <field name="patterns">
+              <collection type="java.util.ArrayList" item-type="java.lang.String">
+                <value>
+                  <string>/.*/tasks/taskDetail/.*</string>
+                </value>
+                <value>
+                  <string>/.*/tasks/projectDetail/.*</string>
+                </value>
+              </collection>
+            </field>
+          </object>
+        </object-param>
+      </init-params>
+    </component-plugin>
+  </external-component-plugins>
+</configuration>

--- a/webapps/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/webapps/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -221,6 +221,31 @@
       <module>taskCommentsDrawer</module>
     </depends>
   </module>
+  
+  <portlet>
+    <name>RestrictedProject</name>
+    <module>
+      <script>
+        <minify>false</minify>
+        <path>/js/restrictedProject.bundle.js</path>
+      </script>
+      <depends>
+        <module>commonVueComponents</module>
+      </depends>
+      <depends>
+        <module>vue</module>
+      </depends>
+      <depends>
+        <module>vuetify</module>
+      </depends>
+      <depends>
+        <module>eXoVueI18n</module>
+      </depends>
+      <depends>
+        <module>extensionRegistry</module>
+      </depends>
+    </module>
+  </portlet>
 
   <portlet>
     <name>TasksManagement</name>

--- a/webapps/src/main/webapp/WEB-INF/portlet.xml
+++ b/webapps/src/main/webapp/WEB-INF/portlet.xml
@@ -74,5 +74,25 @@
       <title>Task Management</title>
     </portlet-info>
   </portlet>
+  <portlet>
+    <portlet-name>RestrictedProject</portlet-name>
+    <portlet-class>org.exoplatform.commons.api.portlet.GenericDispatchedViewPortlet</portlet-class>
+    <init-param>
+      <name>portlet-view-dispatched-file-path</name>
+      <value>/html/restrictedProject.html</value>
+    </init-param>
+    <init-param>
+      <name>layout-css-class</name>
+      <value>no-layout-background-color no-layout-border-radius no-layout-border</value>
+    </init-param>
+    <supports>
+      <mime-type>text/html</mime-type>
+    </supports>
+    <supported-locale>en</supported-locale>
+    <resource-bundle>locale.portlet.restrictedProject</resource-bundle>
+    <portlet-info>
+      <title>Restricted Project</title>
+    </portlet-info>
+  </portlet>
 
 </portlet-app>

--- a/webapps/src/main/webapp/html/restrictedProject.html
+++ b/webapps/src/main/webapp/html/restrictedProject.html
@@ -1,0 +1,7 @@
+<div class="VuetifyApp">
+  <div id="restrictedProject">
+    <script type="text/javascript">
+      require(['PORTLET/task-management/RestrictedProject'], app => app.init());
+    </script>
+  </div>
+</div>

--- a/webapps/src/main/webapp/vue-app/restricted-project/components/RestrictedProject.vue
+++ b/webapps/src/main/webapp/vue-app/restricted-project/components/RestrictedProject.vue
@@ -1,0 +1,44 @@
+<!--
+
+ This file is part of the Meeds project (https://meeds.io/).
+
+ Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+
+ This program is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 3 of the License, or (at your option) any later version.
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public License
+ along with this program; if not, write to the Free Software Foundation,
+ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+-->
+<template>
+  <v-card
+    class="application-body py-9 text-center"
+    flat>
+    <v-card-text class="mt-12">
+      <v-icon color="primary" class="fa-7x">fa-door-open</v-icon>
+    </v-card-text>
+    <v-card-text
+      class="text-title"
+      v-sanitized-html="$t('text.title')" />
+    <v-card-text
+      class="text-body"
+      v-sanitized-html="fullBody" />
+  </v-card>
+</template>
+<script>
+export default {
+  computed: {
+    fullBody() {
+      return this.$t('text.body').concat( '<br>'.concat(this.$t('text.sub.body')));
+    }
+  }
+};
+</script>

--- a/webapps/src/main/webapp/vue-app/restricted-project/initComponents.js
+++ b/webapps/src/main/webapp/vue-app/restricted-project/initComponents.js
@@ -1,0 +1,27 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ * 
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+import RestrictedProject from './components/RestrictedProject.vue';
+
+const components = {
+  'restricted-project': RestrictedProject,
+};
+
+for (const key in components) {
+  Vue.component(key, components[key]);
+}

--- a/webapps/src/main/webapp/vue-app/restricted-project/main.js
+++ b/webapps/src/main/webapp/vue-app/restricted-project/main.js
@@ -1,0 +1,42 @@
+/*
+ * This file is part of the Meeds project (https://meeds.io/).
+ * 
+ * Copyright (C) 2020 - 2026 Meeds Association contact@meeds.io
+ * 
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+import './initComponents.js';
+
+if (extensionRegistry) {
+  const components = extensionRegistry.loadComponents('RestrictedProject');
+  if (components && components.length > 0) {
+    components.forEach(cmp => {
+      Vue.component(cmp.componentName, cmp.componentOptions);
+    });
+  }
+}
+
+const appId = 'restrictedProject';
+const lang = typeof eXo !== 'undefined' ? eXo.env.portal.language : 'en';
+const url = `/task-management/i18n/locale.portlet.restrictedProject?lang=${lang}.json`;
+
+export function init() {
+  exoi18n.loadLanguageAsync(lang, url).then(i18n => {
+    Vue.createApp({
+      template: `<restricted-project id="${appId}"/>`,
+      vuetify: Vue.prototype.vuetifyOptions,
+      i18n,
+    }, `#${appId}`, 'Project Header');
+  });
+}

--- a/webapps/webpack.common.js
+++ b/webapps/webpack.common.js
@@ -33,6 +33,7 @@ const config = {
     notificationExtension: './src/main/webapp/vue-app/notification-extension/main.js',
     taskQuickAction: './src/main/webapp/vue-app/quick-actions/main.js',
     taskContentLinkExtension: './src/main/webapp/vue-app/content-link/extensions.js',
+    restrictedProject: './src/main/webapp/vue-app/restricted-project/main.js',
   },
   output: {
     filename: 'js/[name].bundle.js',


### PR DESCRIPTION
Before this change, if no longer belongs to an accessible project, task url displays blank content. After this change, the restricted page displays correctly, and its URL should be /restricted-project.