### PR TITLE
fix: Fix task creator can no longer see or add attachments - EXO-85191

### DIFF
--- a/services/src/main/java/org/exoplatform/task/integration/TaskAttachmentPlugin.java
+++ b/services/src/main/java/org/exoplatform/task/integration/TaskAttachmentPlugin.java
@@ -55,8 +55,7 @@ public class TaskAttachmentPlugin extends AttachmentPlugin {
   public boolean hasAccessPermission(Identity userIdentity, String entityId) throws ObjectNotFoundException {
     try {
       TaskDto task = taskService.getTask(Long.parseLong(entityId));
-      return TaskUtil.hasViewPermission(taskService, task, userIdentity)
-          || (task.getCreatedBy() != null && task.getCreatedBy().equals(userIdentity.getUserId()));
+      return TaskUtil.hasViewPermission(taskService, task, userIdentity);
     } catch (Exception e) {
       throw new ObjectNotFoundException(String.format(TASK_NOT_FOUND_EXCEPTION_MESSAGE, entityId));
     }
@@ -66,8 +65,7 @@ public class TaskAttachmentPlugin extends AttachmentPlugin {
   public boolean hasEditPermission(Identity userIdentity, String entityId) throws ObjectNotFoundException {
     try {
       TaskDto task = taskService.getTask(Long.parseLong(entityId));
-      return TaskUtil.hasEditPermission(taskService, task, userIdentity)
-          || (task.getCreatedBy() != null && task.getCreatedBy().equals(userIdentity.getUserId()));
+      return TaskUtil.hasEditPermission(taskService, task, userIdentity);
     } catch (Exception e) {
       throw new ObjectNotFoundException(String.format(TASK_NOT_FOUND_EXCEPTION_MESSAGE, entityId));
     }

--- a/services/src/main/java/org/exoplatform/task/rest/TaskRestService.java
+++ b/services/src/main/java/org/exoplatform/task/rest/TaskRestService.java
@@ -966,7 +966,7 @@ public class TaskRestService implements ResourceContainer {
     if (task == null) {
       return Response.status(Response.Status.NOT_FOUND).build();
     }
-    if (!TaskUtil.hasEditPermission(taskService,task) && (task.getCreatedBy() == null || !task.getCreatedBy().equals(currentUser))) {//The task creator can add comments
+    if (!TaskUtil.hasEditPermission(taskService, task, currentUserIdentity)) {//The task creator can add comments
       return Response.status(Response.Status.FORBIDDEN).build();
     }
     commentText = commentText.replaceAll(PERCENT_ENCODED_REGEX, "%25");
@@ -1005,7 +1005,7 @@ public class TaskRestService implements ResourceContainer {
     if (task == null) {
       return Response.status(Response.Status.NOT_FOUND).build();
     }
-    if (!TaskUtil.hasEditPermission(taskService,task) && (task.getCreatedBy() == null || !task.getCreatedBy().equals(currentUser))) {//The task creator can add sub comments
+    if (!TaskUtil.hasEditPermission(taskService, task, currentUserIdentity)) {//The task creator can add sub comments
       return Response.status(Response.Status.FORBIDDEN).build();
     }
 


### PR DESCRIPTION
Prior to this change, the task creator can't see or add attachments due to a wrong permission for these actions. After this comment, these actions will be allowed for the task creator.