### PR TITLE
fix: Fix add/edit task project event XSS vulnerability - EXO-86231

### DIFF
--- a/services/src/main/java/org/exoplatform/task/service/ProjectService.java
+++ b/services/src/main/java/org/exoplatform/task/service/ProjectService.java
@@ -18,14 +18,13 @@
  */
 package org.exoplatform.task.service;
 
-import org.exoplatform.commons.utils.ListAccess;
+import java.util.List;
+import java.util.Set;
+
 import org.exoplatform.task.dao.OrderBy;
 import org.exoplatform.task.dao.ProjectQuery;
 import org.exoplatform.task.dto.ProjectDto;
 import org.exoplatform.task.exception.EntityNotFoundException;
-
-import java.util.List;
-import java.util.Set;
 
 
 public interface ProjectService {

--- a/services/src/main/java/org/exoplatform/task/service/impl/ProjectServiceImpl.java
+++ b/services/src/main/java/org/exoplatform/task/service/impl/ProjectServiceImpl.java
@@ -190,7 +190,6 @@ public class ProjectServiceImpl implements ProjectService {
   @Override
   public List<ProjectDto> getSubProjects(long parentId, int offset, int limit) {
     try {
-      ProjectDto parent = getProject(parentId);
       return projectStorage.getSubProjects(parentId, offset, limit);
     } catch (Exception ex) {
       return new ArrayList<ProjectDto>();

--- a/services/src/main/java/org/exoplatform/task/util/StorageUtil.java
+++ b/services/src/main/java/org/exoplatform/task/util/StorageUtil.java
@@ -226,7 +226,7 @@ public final class StorageUtil{
         }
         ProjectDto projectDto = new ProjectDto();
         projectDto.setId(project.getId());
-        projectDto.setName(project.getName());
+        projectDto.setName(HTMLSanitizer.sanitize(project.getName()));
         projectDto.setDescription(project.getDescription());
         projectDto.setColor(project.getColor());
         projectDto.setDueDate(project.getDueDate());
@@ -234,9 +234,6 @@ public final class StorageUtil{
         projectDto.setParticipator(projectStorage.getParticipator(project.getId()));
         projectDto.setManager(projectStorage.getManager(project.getId()));
         projectDto.setParent(projectToDto(project.getParent(),projectStorage));
-        //if(project.getStatus()!=null)projectDto.setStatus(project.getStatus().stream().map(status -> statusToDTO(status,projectStorage)).collect(Collectors.toSet()));
-
-        //if(project.getChildren()!=null)projectDto.setChildren(project.getChildren().stream().map(this::projectToDto).collect(Collectors.toList()));
         return projectDto;
     }
 


### PR DESCRIPTION
Prior to this change, when creating or editing a task project, a JavaScript payload inserted in the name field could be executed when the task project is deleted, leading to an XSS vulnerability. 
After this commit, the name value is sanitized using HTMLSanitizer.sanitize when getting the project dto, preventing the XSS vulnerability.

Resolves Meeds-io/si#11