### PR TITLE
feat: Add ContentType Definition in Search Connector - EXO-86376

### DIFF
--- a/webapps/src/main/webapp/WEB-INF/conf/task-addon/search-configuration.xml
+++ b/webapps/src/main/webapp/WEB-INF/conf/task-addon/search-configuration.xml
@@ -37,6 +37,9 @@
             <field name="name">
               <string>tasks</string>
             </field>
+            <field name="contentType">
+              <string>task</string>
+            </field>
             <field name="uri">
               <string><![CDATA[/portal/rest/tasks?limit={limit}&q={keyword}]]></string>
             </field>


### PR DESCRIPTION
This change will allow to define the associated `contentType` for each Search Connector to allow automatic filtering on content types.