### PR TITLE
fix: Task description lost when typing a title - EXO-87301

### DIFF
--- a/webapps/src/main/webapp/vue-app/taskDrawer/components/TaskDrawer.vue
+++ b/webapps/src/main/webapp/vue-app/taskDrawer/components/TaskDrawer.vue
@@ -127,6 +127,7 @@
               rows="1"
               row-height="13"
               required
+              @input="onTitleInput"
               @change="updateTaskTitle" />
           </div>
           <div
@@ -421,6 +422,9 @@ export default {
         this.task.title = this.oldTask.title = this.taskTitle;
       }
     },
+    onTitleInput() {
+      document.dispatchEvent(new CustomEvent('onAddTaskDescription'));
+    },
     updateCompleted() {
       const task = {
         id: this.task.id,
@@ -678,7 +682,9 @@ export default {
       }
     },
     addTaskDescription(value) {
-      this.taskDescription = value;
+      if (this.taskDescription !== value) {
+        this.taskDescription = value;
+      }
     },
     retrieveTaskLogs() {
       this.$taskDrawerApi.getTaskLogs(this.task.id).then(

--- a/webapps/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskDescriptionEditor.vue
+++ b/webapps/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskDescriptionEditor.vue
@@ -152,6 +152,9 @@ export default {
       this.$emit('addTaskDescription',this.value);
       this.showEditor = false;
     });
+    document.addEventListener('onAddTaskDescription', () => {
+      this.$emit('addTaskDescription',this.value);
+    });
     this.inputVal = this.value || '';
     $('#task-Drawer').on('click', (event) => {
       if (this.showEditor && event?.target && !$(event.target).parents('#taskDescriptionId').length) {


### PR DESCRIPTION
Before this change, when a user started creating a new task, entered a description in the rich editor and then began typing the task title, the description was lost. This happened because the description editor was destroyed when interacting with the title field, without properly synchronizing its current content. To fix this problem, an event was introduced on the title input (@input) to trigger a synchronization of the current description before any further UI changes affecting the editor lifecycle. After this change, when the user starts typing the task title, a custom event (onAddTask) is dispatched from the title input handler to ensure the current description is captured and preserved before the editor is destroyed. As a result, the task description is no longer lost when switching from description editing to title input during task creation.