### PR TITLE
fix: Task description lost when typing a title - EXO-87301

### DIFF
--- a/webapps/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskDescriptionEditor.vue
+++ b/webapps/src/main/webapp/vue-app/taskDrawer/components/TaskDrawerComponents/TaskDescriptionEditor.vue
@@ -155,6 +155,7 @@ export default {
     this.inputVal = this.value || '';
     $('#task-Drawer').on('click', (event) => {
       if (this.showEditor && event?.target && !$(event.target).parents('#taskDescriptionId').length) {
+        this.$emit('input', this.value);
         this.hideDescriptionEditor();
       }
     });


### PR DESCRIPTION
Before this change, when a user started creating a new task, entered a description in the rich editor and then began typing the task title, the description was lost. This happened because the description editor was destroyed when interacting with the title field, without properly synchronizing its current content. To fix this problem, this.('input', this.value) was added to the created hook of the TaskDescriptionEditor to ensure the description value is properly propagated to the parent component before the editor is destroyed. After this change, whenever the description editor is closed (such as when clicking outside the editor or switching to another field), the current value is explicitly emitted to the parent component before destroying the editor. This ensures that the task description is always preserved and no longer lost during transitions between editing the description and other task fields.