### PR TITLE
fix: Avoid Error Log when NoResultException is thrown - EXO-87643

### DIFF
--- a/services/src/main/java/org/exoplatform/task/dao/jpa/LabelTaskMappingDAOImpl.java
+++ b/services/src/main/java/org/exoplatform/task/dao/jpa/LabelTaskMappingDAOImpl.java
@@ -26,6 +26,7 @@ import org.exoplatform.services.log.Log;
 import org.exoplatform.task.dao.LabelTaskMappingHandler;
 import org.exoplatform.task.domain.LabelTaskMapping;
 
+import jakarta.persistence.NoResultException;
 import jakarta.persistence.PersistenceException;
 import jakarta.persistence.TypedQuery;
 
@@ -54,8 +55,10 @@ public class LabelTaskMappingDAOImpl extends CommonJPADAO<LabelTaskMapping, Seri
     query.setParameter(TASK_ID, taskId);
     try {
       return cloneEntity(query.getSingleResult());
+    } catch (NoResultException e) {
+      return null;
     } catch (PersistenceException e) {
-      log.error("Error when fetching label mapping", e);
+      log.warn("Error when fetching label mapping. Return null Task label", e);
       return null;
     }
   }


### PR DESCRIPTION
Prior to this change, a useless Log Entry is added when a JPA Query returned no results. This change catches this exception and returns a null without logging instead.