### PR TITLE
fix: Allow to a space manager user to clone a Task - EXO-87676

### DIFF
--- a/webapps/src/main/webapp/vue-app/taskDrawer/components/TaskDrawer.vue
+++ b/webapps/src/main/webapp/vue-app/taskDrawer/components/TaskDrawer.vue
@@ -831,7 +831,7 @@ export default {
           this.addMenuAction(menuActions, this.$t('label.delete'), 'uiIconTrash', this.enableDelete, 'deleteTask', 10);
           this.addMenuAction(menuActions, this.$t('label.clone'), 'uiIconCloneNode', this.enableClone, 'cloneTask', 20);
           menuActions.sort((a, b) => a.rank - b.rank);
-          this.menuActions = menuActions.filter(menuAction => menuAction.enabled === false || (typeof menuAction?.enabled === 'function' && menuAction?.enabled?.(task)));
+          this.menuActions = menuActions.filter(menuAction => menuAction.enabled === true || (typeof menuAction?.enabled === 'function' && menuAction?.enabled?.(task)));
         });
       } else if ( task && task.id ) {
         this.enableDelete = task.createdBy === eXo.env.portal.userName;
@@ -839,7 +839,7 @@ export default {
         this.addMenuAction(menuActions, this.$t('label.delete'), 'uiIconTrash', this.enableDelete, 'deleteTask', 10);
         this.addMenuAction(menuActions, this.$t('label.clone'), 'uiIconCloneNode', this.enableClone, 'cloneTask', 20);
         menuActions.sort((a, b) => a.rank - b.rank);
-        this.menuActions = menuActions.filter(menuAction => menuAction.enabled === true || menuAction?.enabled?.(task));
+        this.menuActions = menuActions.filter(menuAction => menuAction.enabled === true || (typeof menuAction?.enabled === 'function' && menuAction?.enabled?.(task)));
       }
     },
 


### PR DESCRIPTION
Prior to this change, the Task cloning feature isn't enabled for a simple user designated as space manager. This change ensures to give access to the clone Task UI for any space manager.