### PR TITLE
feat: migrate statistic fields to typed collection API - EXO-87596

### DIFF
--- a/services/src/main/java/org/exoplatform/tasks/listener/analytics/TaskCommentListener.java
+++ b/services/src/main/java/org/exoplatform/tasks/listener/analytics/TaskCommentListener.java
@@ -100,7 +100,7 @@ public class TaskCommentListener extends Listener<TaskService, CommentDto> {
 
     Space space = getSpaceOfProject(task);
     addSpaceStatistics(statisticData, space);
-    statisticData.addParameter("taskId", task.getId());
+    statisticData.addKeyword("taskId", task.getId());
     appendTaskProperties(statisticData, task, null);
     addCommentProperties(statisticData, comment);
 
@@ -108,10 +108,10 @@ public class TaskCommentListener extends Listener<TaskService, CommentDto> {
   }
 
   private void addCommentProperties(StatisticData statisticData, CommentDto comment) {
-    statisticData.addParameter("commentId", comment.getId());
-    statisticData.addParameter("authorId", getUserIdentityId(comment.getAuthor()));
-    statisticData.addParameter("commentLength", comment.getComment() == null ? 0 : comment.getComment().length());
-    statisticData.addParameter("isSubComment", comment.getParentComment() != null);
+    statisticData.addKeyword("commentId", comment.getId());
+    statisticData.addKeyword("authorId", getUserIdentityId(comment.getAuthor()));
+    statisticData.addLong("commentLength", comment.getComment() == null ? 0 : comment.getComment().length());
+    statisticData.addBoolean("isSubComment", comment.getParentComment() != null);
   }
 
   private void appendTaskProperties(StatisticData statisticData, TaskDto task, String prefix) {
@@ -123,13 +123,13 @@ public class TaskCommentListener extends Listener<TaskService, CommentDto> {
     }
     ProjectDto project = task.getStatus() == null ? null : task.getStatus().getProject();
     if (project != null) {
-      statisticData.addParameter(prefix + "projectId", project.getId());
+      statisticData.addKeyword(prefix + "projectId", project.getId());
     }
 
-    statisticData.addParameter(prefix + "activityId", task.getActivityId());
+    statisticData.addKeyword(prefix + "activityId", task.getActivityId());
 
     long assigneeId = getUserIdentityId(task.getAssignee());
-    statisticData.addParameter(prefix + "assigneeId", assigneeId);
+    statisticData.addKeyword(prefix + "assigneeId", assigneeId);
 
     List<Long> assigneeIds = new ArrayList<>();
     assigneeIds.add(assigneeId);
@@ -140,39 +140,39 @@ public class TaskCommentListener extends Listener<TaskService, CommentDto> {
         long coworderId = getUserIdentityId(coworker);
         coworkerIds.add(coworderId);
       });
-      statisticData.addParameter(prefix + "coworkerIds", coworkerIds);
+      statisticData.addKeywords(prefix + "coworkerIds", coworkerIds);
 
       assigneeIds.addAll(coworkerIds);
     }
-    statisticData.addParameter(prefix + "assigneeIds", assigneeIds);
+    statisticData.addKeywords(prefix + "assigneeIds", assigneeIds);
 
-    statisticData.addParameter(prefix + "creatorId", getUserIdentityId(task.getCreatedBy()));
-    statisticData.addParameter(prefix + "rank", task.getRank());
+    statisticData.addKeyword(prefix + "creatorId", getUserIdentityId(task.getCreatedBy()));
+    statisticData.addLong(prefix + "rank", task.getRank());
     if (task.getDueDate() != null) {
-      statisticData.addParameter(prefix + "dueDate", task.getDueDate());
+      statisticData.addDate(prefix + "dueDate", task.getDueDate());
     }
     if (task.getCreatedTime() != null) {
-      statisticData.addParameter(prefix + "createdTime", task.getCreatedTime());
+      statisticData.addDate(prefix + "createdTime", task.getCreatedTime());
     }
     if (task.getStartDate() != null) {
-      statisticData.addParameter(prefix + "startDate", task.getStartDate());
+      statisticData.addDate(prefix + "startDate", task.getStartDate());
     }
     if (task.getEndDate() != null) {
-      statisticData.addParameter(prefix + "endDate", task.getEndDate());
+      statisticData.addDate(prefix + "endDate", task.getEndDate());
     }
     if (task.getPriority() != null) {
-      statisticData.addParameter(prefix + "priority", task.getPriority().name());
+      statisticData.addKeyword(prefix + "priority", task.getPriority().name());
     }
     if (task.getTitle() != null) {
-      statisticData.addParameter(prefix + "titleLength", task.getTitle().length());
+      statisticData.addLong(prefix + "titleLength", task.getTitle().length());
     }
     if (task.getDescription() != null) {
-      statisticData.addParameter(prefix + "descriptionLength", task.getDescription().length());
+      statisticData.addLong(prefix + "descriptionLength", task.getDescription().length());
     }
     if (task.getStatus() != null) {
-      statisticData.addParameter(prefix + "statusId", task.getStatus().getId());
-      statisticData.addParameter(prefix + "statusName", task.getStatus().getName());
-      statisticData.addParameter(prefix + "statusRank", task.getStatus().getRank());
+      statisticData.addKeyword(prefix + "statusId", task.getStatus().getId());
+      statisticData.addKeyword(prefix + "statusName", task.getStatus().getName());
+      statisticData.addLong(prefix + "statusRank", task.getStatus().getRank());
     }
   }
 

--- a/services/src/main/java/org/exoplatform/tasks/listener/analytics/TaskLabelListener.java
+++ b/services/src/main/java/org/exoplatform/tasks/listener/analytics/TaskLabelListener.java
@@ -63,12 +63,12 @@ public class TaskLabelListener extends Listener<String, LabelTaskMapping> {
     statisticData.setUserId(AnalyticsUtils.getUserIdentityId(userName));
     statisticData.setOperation(operation);
     if (labelTaskMapping.getTask() != null) {
-      statisticData.addParameter("taskId", labelTaskMapping.getTask().getId());
+      statisticData.addKeyword("taskId", labelTaskMapping.getTask().getId());
     }
     if (labelTaskMapping.getLabel() != null) {
-      statisticData.addParameter("labelId", labelTaskMapping.getLabel().getId());
+      statisticData.addKeyword("labelId", labelTaskMapping.getLabel().getId());
       if (labelTaskMapping.getLabel().getProject() != null) {
-        statisticData.addParameter("projectId", labelTaskMapping.getLabel().getProject().getId());
+        statisticData.addKeyword("projectId", labelTaskMapping.getLabel().getProject().getId());
       }
     }
     AnalyticsUtils.addStatisticData(statisticData);

--- a/services/src/main/java/org/exoplatform/tasks/listener/analytics/TaskSavedListener.java
+++ b/services/src/main/java/org/exoplatform/tasks/listener/analytics/TaskSavedListener.java
@@ -110,10 +110,10 @@ public class TaskSavedListener extends Listener<TaskService, TaskPayload> {
 
     Space space = getSpaceOfProject(newTask);
     addSpaceStatistics(statisticData, space);
-    statisticData.addParameter("taskId", newTask.getId());
+    statisticData.addKeyword("taskId", newTask.getId());
 
     List<Long> taskLabelIds = taskLabels.stream().map(LabelDto::getId).collect(Collectors.toList());
-    statisticData.addParameter("taskLabelIds", taskLabelIds);
+    statisticData.addKeywords("taskLabelIds", taskLabelIds);
 
     appendTaskProperties(statisticData, newTask, null);
 
@@ -169,13 +169,13 @@ public class TaskSavedListener extends Listener<TaskService, TaskPayload> {
     }
     ProjectDto project = task.getStatus() == null ? null : task.getStatus().getProject();
     if (project != null) {
-      statisticData.addParameter(prefix + "projectId", project.getId());
+      statisticData.addKeyword(prefix + "projectId", project.getId());
     }
 
-    statisticData.addParameter(prefix + "activityId", task.getActivityId());
+    statisticData.addKeyword(prefix + "activityId", task.getActivityId());
 
     long assigneeId = getUserIdentityId(task.getAssignee());
-    statisticData.addParameter(prefix + "assigneeId", assigneeId);
+    statisticData.addKeyword(prefix + "assigneeId", assigneeId);
 
     List<Long> assigneeIds = new ArrayList<>();
     assigneeIds.add(assigneeId);
@@ -186,39 +186,39 @@ public class TaskSavedListener extends Listener<TaskService, TaskPayload> {
         long coworderId = getUserIdentityId(coworker);
         coworkerIds.add(coworderId);
       });
-      statisticData.addParameter(prefix + "coworkerIds", coworkerIds);
+      statisticData.addKeywords(prefix + "coworkerIds", coworkerIds);
 
       assigneeIds.addAll(coworkerIds);
     }
-    statisticData.addParameter(prefix + "assigneeIds", assigneeIds);
+    statisticData.addKeywords(prefix + "assigneeIds", assigneeIds);
 
-    statisticData.addParameter(prefix + "creatorId", getUserIdentityId(task.getCreatedBy()));
-    statisticData.addParameter(prefix + "rank", task.getRank());
+    statisticData.addKeyword(prefix + "creatorId", getUserIdentityId(task.getCreatedBy()));
+    statisticData.addLong(prefix + "rank", task.getRank());
     if (task.getDueDate() != null) {
-      statisticData.addParameter(prefix + "dueDate", task.getDueDate());
+      statisticData.addDate(prefix + "dueDate", task.getDueDate());
     }
     if (task.getCreatedTime() != null) {
-      statisticData.addParameter(prefix + "createdTime", task.getCreatedTime());
+      statisticData.addDate(prefix + "createdTime", task.getCreatedTime());
     }
     if (task.getStartDate() != null) {
-      statisticData.addParameter(prefix + "startDate", task.getStartDate());
+      statisticData.addDate(prefix + "startDate", task.getStartDate());
     }
     if (task.getEndDate() != null) {
-      statisticData.addParameter(prefix + "endDate", task.getEndDate());
+      statisticData.addDate(prefix + "endDate", task.getEndDate());
     }
     if (task.getPriority() != null) {
-      statisticData.addParameter(prefix + "priority", task.getPriority().name());
+      statisticData.addKeyword(prefix + "priority", task.getPriority().name());
     }
     if (task.getTitle() != null) {
-      statisticData.addParameter(prefix + "titleLength", task.getTitle().length());
+      statisticData.addLong(prefix + "titleLength", task.getTitle().length());
     }
     if (task.getDescription() != null) {
-      statisticData.addParameter(prefix + "descriptionLength", task.getDescription().length());
+      statisticData.addLong(prefix + "descriptionLength", task.getDescription().length());
     }
     if (task.getStatus() != null) {
-      statisticData.addParameter(prefix + "statusId", task.getStatus().getId());
-      statisticData.addParameter(prefix + "statusName", task.getStatus().getName());
-      statisticData.addParameter(prefix + "statusRank", task.getStatus().getRank());
+      statisticData.addKeyword(prefix + "statusId", task.getStatus().getId());
+      statisticData.addKeyword(prefix + "statusName", task.getStatus().getName());
+      statisticData.addLong(prefix + "statusRank", task.getStatus().getRank());
     }
   }
 


### PR DESCRIPTION
Replace deprecated StatisticData#addParameter usages with explicit typed APIs across product modules.

Use addKeyword/addKeywords for identifiers and labels, addLong for numeric aggregation fields, and typed collection variants where needed. This makes the intended Elasticsearch mapping explicit at producer level and avoids accidental field type changes or unnecessary *_alt mapping creation.