### PR TITLE
fix: Increase "CMT" column size in TASK_COMMENTS table - EXO-87818

### DIFF
--- a/services/src/main/resources/db/changelog/task.db.changelog-1.0.0.xml
+++ b/services/src/main/resources/db/changelog/task.db.changelog-1.0.0.xml
@@ -532,4 +532,10 @@
       ALTER TABLE TASK_PROJECTS MODIFY COLUMN NAME varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
     </sql>
   </changeSet>
+  
+  <changeSet author="task" id="1.0.0-38">
+    <modifyDataType columnName="CMT"
+                    newDataType="NVARCHAR(4000)"
+                    tableName="TASK_COMMENTS"/>
+  </changeSet>
 </databaseChangeLog>

--- a/services/src/main/resources/db/changelog/task.db.changelog-1.0.0.xml
+++ b/services/src/main/resources/db/changelog/task.db.changelog-1.0.0.xml
@@ -537,5 +537,8 @@
     <modifyDataType columnName="CMT"
                     newDataType="NVARCHAR(4000)"
                     tableName="TASK_COMMENTS"/>
+	<modifySql dbms="mysql">
+      <replace replace="NVARCHAR(4000)" with="VARCHAR(4000) CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci" />
+    </modifySql>
   </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
Prior to this change, when a task comment contained links or formatting, CKEditor would add HTML tags, sometimes causing the comment length to exceed the 2000-character limit of the "CMT" column in TASK_COMMENTS table. This resulted in SQL data truncation exceptions and prevented the comment from being saved. 
This change increases the maximum length of the "CMT" column in TASK_COMMENTS table from NVARCHAR(2000) to NVARCHAR(4000) to support longer comments including HTML markup generated by CKEditor.